### PR TITLE
Altered command to install without cseabreeze

### DIFF
--- a/docs/LINUX_INSTALL.md
+++ b/docs/LINUX_INSTALL.md
@@ -88,7 +88,7 @@ pip install .
 or if you do not want to build the cseabreeze wrapper:
 
 ```
-python setup.py install --without-seabreeze
+python setup.py install --without-cseabreeze
 ```
 
 You made it. Congratulations.


### PR DESCRIPTION
The original version does not work, because the code assumes "--without-cseabreeze"*.
So I changed it to:
```
python setup.py install --without-cseabreeze
```

*= https://github.com/ap--/python-seabreeze/blob/master/setup.py#L9