### PR TITLE
Fix functions' name,  Raise NotImplementedError, Update spectrometers.py

### DIFF
--- a/docs/LINUX_INSTALL.md
+++ b/docs/LINUX_INSTALL.md
@@ -93,7 +93,11 @@ python setup.py install --without-cseabreeze
 
 You made it. Congratulations.
 
+Note: If you want to build cseabreeze，you should install Cython.
 
+```
+pip install cython
+```
 ## Common problems
 
 #### python-seabreeze can't find my spectrometer

--- a/seabreeze/cseabreeze/__init__.py
+++ b/seabreeze/cseabreeze/__init__.py
@@ -52,4 +52,9 @@ from .wrapper import (SeaBreezeError,
                       tec_set_enable,
                       lamp_set_lamp_enable,
                       nonlinearity_coeffs_get,
-                      stray_light_coeffs_get)
+                      stray_light_coeffs_get,
+                      device_get_spectrum_processing_feature_id,
+                      spectrometer_set_boxcar_width,
+                      spectrometer_set_scans_to_average,
+                      spectrometer_get_boxcar_width,
+                      spectrometer_get_scans_to_average)

--- a/seabreeze/cseabreeze/__init__.py
+++ b/seabreeze/cseabreeze/__init__.py
@@ -54,7 +54,7 @@ from .wrapper import (SeaBreezeError,
                       nonlinearity_coeffs_get,
                       stray_light_coeffs_get,
                       device_get_spectrum_processing_feature_id,
-                      spectrometer_set_boxcar_width,
-                      spectrometer_set_scans_to_average,
-                      spectrometer_get_boxcar_width,
-                      spectrometer_get_scans_to_average)
+                      spectrum_processing_set_boxcar_width,
+                      spectrum_processing_set_scans_to_average,
+                      spectrum_processing_get_boxcar_width,
+                      spectrum_processing_get_scans_to_average)

--- a/seabreeze/cseabreeze/cseabreeze.pxd
+++ b/seabreeze/cseabreeze/cseabreeze.pxd
@@ -25,6 +25,8 @@ cdef extern:
     void sbapi_spectrometer_set_trigger_mode(long deviceID, long featureID, int *error_code, int mode) nogil
     void sbapi_spectrometer_set_integration_time_micros(long deviceID, long featureID, int *error_code, unsigned long integration_time_micros) nogil
     long sbapi_spectrometer_get_minimum_integration_time_micros(long deviceID, long featureID, int *error_code) nogil
+
+
     int sbapi_spectrometer_get_formatted_spectrum_length(long deviceID, long featureID, int *error_code) nogil
     int sbapi_spectrometer_get_formatted_spectrum(long deviceID, long featureID, int *error_code, double* buffer, int buffer_length) nogil
     int sbapi_spectrometer_get_unformatted_spectrum_length(long deviceID, long featureID, int *error_code) nogil
@@ -81,3 +83,12 @@ cdef extern:
     int sbapi_get_number_of_stray_light_coeffs_features(long deviceID, int *error_code)
     int sbapi_get_stray_light_coeffs_features(long deviceID, int *error_code, long *features, int max_features)
     int sbapi_stray_light_coeffs_get(long deviceID, long featureID, int *error_code, double *buffer, int max_length)
+
+    # wrapper for spectrum processing features
+
+    int sbapi_get_number_of_spectrum_processing_features(long deviceID, int *error_code)
+    int sbapi_get_spectrum_processing_features(long deviceID, int *error_code, long *features, int max_features)
+    unsigned short int sbapi_spectrum_processing_scans_to_average_get(long deviceID, long featureID, int *error_code) nogil
+    unsigned char sbapi_spectrum_processing_boxcar_width_get(long deviceID, long featureID, int *error_code) nogil
+    void sbapi_spectrum_processing_scans_to_average_set(long deviceID, long featureID, int *error_code, unsigned short int scansToAverage) nogil
+    void sbapi_spectrum_processing_boxcar_width_set(long deviceID, long featureID, int *error_code, unsigned char boxcarWidth) nogil

--- a/seabreeze/cseabreeze/wrapper.pyx
+++ b/seabreeze/cseabreeze/wrapper.pyx
@@ -629,21 +629,21 @@ def device_get_spectrum_processing_feature_id(SeaBreezeDevice device not None):
                 "%d tec features. The code expects it to have 0 or 1. "
                 "Please file a bug report including a description of your device." % N)
 
-def spectrometer_set_boxcar_width(SeaBreezeDevice device not None, long featureID, unsigned char boxcar_width):
+def spectrum_processing_set_boxcar_width(SeaBreezeDevice device not None, long featureID, unsigned char boxcar_width):
     cdef int error_code
     with nogil:
         csb.sbapi_spectrum_processing_boxcar_width_set(device.handle, featureID, &error_code, boxcar_width)
     if error_code != 0:
         raise SeaBreezeError(error_code=error_code)
     
-def spectrometer_set_scans_to_average(SeaBreezeDevice device not None, long featureID, unsigned short int scans_to_average):
+def spectrum_processing_set_scans_to_average(SeaBreezeDevice device not None, long featureID, unsigned short int scans_to_average):
     cdef int error_code
     with nogil:
         csb.sbapi_spectrum_processing_scans_to_average_set(device.handle, featureID, &error_code, scans_to_average)
     if error_code != 0:
         raise SeaBreezeError(error_code=error_code)
 
-def spectrometer_get_boxcar_width(SeaBreezeDevice device not None, long featureID):
+def spectrum_processing_get_boxcar_width(SeaBreezeDevice device not None, long featureID):
     cdef unsigned char boxcar_width
     cdef int error_code
     with nogil:
@@ -652,7 +652,7 @@ def spectrometer_get_boxcar_width(SeaBreezeDevice device not None, long featureI
         raise SeaBreezeError(error_code=error_code)
     return boxcar_width   
 
-def spectrometer_get_scans_to_average(SeaBreezeDevice device not None, long featureID):
+def spectrum_processing_get_scans_to_average(SeaBreezeDevice device not None, long featureID):
     cdef unsigned short int scans_to_average
     cdef int error_code
     with nogil:

--- a/seabreeze/pyseabreeze/__init__.py
+++ b/seabreeze/pyseabreeze/__init__.py
@@ -52,4 +52,9 @@ from .wrapper import (SeaBreezeError,
                       tec_set_enable,
                       lamp_set_lamp_enable,
                       nonlinearity_coeffs_get,
-                      stray_light_coeffs_get)
+                      stray_light_coeffs_get,
+                      device_get_spectrum_processing_feature_id,
+                      spectrum_processing_set_boxcar_width,
+                      spectrum_processing_set_scans_to_average,
+                      spectrum_processing_get_boxcar_width,
+                      spectrum_processing_get_scans_to_average)

--- a/seabreeze/pyseabreeze/wrapper.py
+++ b/seabreeze/pyseabreeze/wrapper.py
@@ -292,3 +292,19 @@ def stray_light_coeffs_get(device, has_feature):
         raise SeaBreezeError("Error: No such feature on device")
     raise NotImplementedError
 
+# SPECTRUM PROCESSING
+
+def device_get_spectrum_processing_feature_id(SeaBreezeDevice device not None):
+    raise NotImplementedError
+
+def spectrum_processing_set_boxcar_width(SeaBreezeDevice device not None, long featureID, unsigned char boxcar_width):
+    raise NotImplementedError
+    
+def spectrum_processing_set_scans_to_average(SeaBreezeDevice device not None, long featureID, unsigned short int scans_to_average):
+    raise NotImplementedError
+
+def spectrum_processing_get_boxcar_width(SeaBreezeDevice device not None, long featureID):
+    raise NotImplementedError  
+
+def spectrum_processing_get_scans_to_average(SeaBreezeDevice device not None, long featureID):
+    raise NotImplementedError

--- a/seabreeze/spectrometers.py
+++ b/seabreeze/spectrometers.py
@@ -103,7 +103,7 @@ class Spectrometer(object):
         self._fidte = feature.add('tec')
         self._fidnc = feature.add('nonlinearity_coeffs')  # Added
         self._fidsl = feature.add('stray_light_coeffs')
-        self._fidspp = feature.add('spectrum_processing')
+        self._fidspp = feature.add('spectrum_processing') # Not implemented in pyseabreeze
         # get additional information
         self._pixels = lib.spectrometer_get_formatted_spectrum_length(self._dev, self._fidsp)
         self._minimum_integration_time_micros = (
@@ -170,12 +170,19 @@ class Spectrometer(object):
 
     def trigger_mode(self, mode):
         lib.spectrometer_set_trigger_mode(self._dev, self._fidsp, mode)
-        
+
     def boxcar_width(self, boxcar_width):
-        lib.spectrometer_set_boxcar_width(self._dev, self._fidspp, boxcar_width)
+        lib.spectrum_processing_set_boxcar_width(self._dev, self._fidspp, boxcar_width) # Not implemented in pyseabreeze
 
     def scans_to_average(self, scans_to_average):
-        lib.spectrometer_set_scans_to_average(self._dev, self._fidspp, scans_to_average)
+        lib.spectrum_processing_set_scans_to_average(self._dev, self._fidspp, scans_to_average) # Not implemented in pyseabreeze
+
+    def get_boxcar_width(self):
+        lib.spectrum_processing_get_boxcar_width(self._dev, self._fidspp) # Not implemented in pyseabreeze
+
+    def get_scans_to_average(self):
+        lib.spectrum_processing_get_scans_to_average(self._dev, self._fidspp) # Not implemented in pyseabreeze
+
 
     @property
     def serial_number(self):

--- a/seabreeze/spectrometers.py
+++ b/seabreeze/spectrometers.py
@@ -103,6 +103,7 @@ class Spectrometer(object):
         self._fidte = feature.add('tec')
         self._fidnc = feature.add('nonlinearity_coeffs')  # Added
         self._fidsl = feature.add('stray_light_coeffs')
+        self._fidspp = feature.add('spectrum_processing')
         # get additional information
         self._pixels = lib.spectrometer_get_formatted_spectrum_length(self._dev, self._fidsp)
         self._minimum_integration_time_micros = (
@@ -167,8 +168,12 @@ class Spectrometer(object):
         lib.spectrometer_set_integration_time_micros(self._dev,
                                                      self._fidsp, integration_time_micros)
 
-    def trigger_mode(self, mode):
-        lib.spectrometer_set_trigger_mode(self._dev, self._fidsp, mode)
+    def boxcar_width(self, boxcar_width):
+        lib.spectrometer_set_boxcar_width(self._dev, self._fidspp, boxcar_width)
+
+    def scans_to_average(self, scans_to_average):
+        lib.spectrometer_set_scans_to_average(self._dev, self._fidspp, scans_to_average)
+
 
     @property
     def serial_number(self):

--- a/seabreeze/spectrometers.py
+++ b/seabreeze/spectrometers.py
@@ -168,12 +168,14 @@ class Spectrometer(object):
         lib.spectrometer_set_integration_time_micros(self._dev,
                                                      self._fidsp, integration_time_micros)
 
+    def trigger_mode(self, mode):
+        lib.spectrometer_set_trigger_mode(self._dev, self._fidsp, mode)
+        
     def boxcar_width(self, boxcar_width):
         lib.spectrometer_set_boxcar_width(self._dev, self._fidspp, boxcar_width)
 
     def scans_to_average(self, scans_to_average):
         lib.spectrometer_set_scans_to_average(self._dev, self._fidspp, scans_to_average)
-
 
     @property
     def serial_number(self):


### PR DESCRIPTION
Hello Andreas,

Thanks for your commented, I have fixed those problems.

1. Last added spectrometer_* functions in cseabreeze.pyx have been prefixed with spectrum_processing_ .
2.The spectrum_processing_* functions added in cseabreeze backend have been edited in pyseabreeze backend ,and all these raise an NotImplementedError.
3.Update spectrometers.py .

Srooy. Please ignore my poor English and bad habit of using Github, I'm trying to be better. (smile)

Best wishes
Weiqiang Li