### PR TITLE
[pysb] light_enable feature for OOI protocol

### DIFF
--- a/src/seabreeze/pyseabreeze/devices.py
+++ b/src/seabreeze/pyseabreeze/devices.py
@@ -543,6 +543,7 @@ class USB650(SeaBreezeDevice):
         sbf.eeprom.SeaBreezeEEPromFeatureOOI,
         sbf.spectrometer.SeaBreezeSpectrometerFeatureUSB650,
         sbf.rawusb.SeaBreezeRawUSBBusAccessFeature,
+        sbf.lightsource.SeaBreezeLightSourceFeatureOOI,
     )
 
 

--- a/src/seabreeze/pyseabreeze/features/lightsource.py
+++ b/src/seabreeze/pyseabreeze/features/lightsource.py
@@ -1,4 +1,5 @@
 from seabreeze.pyseabreeze.features._base import SeaBreezeFeature
+from seabreeze.pyseabreeze.protocol import OOIProtocol
 
 
 # Definition
@@ -29,3 +30,14 @@ class SeaBreezeLightSourceFeature(SeaBreezeFeature):
 
     def set_intensity(self, light_source_index, intensity):
         raise NotImplementedError("implement in derived class")
+
+class SeaBreezeLightSourceFeatureOOI(SeaBreezeLightSourceFeature):
+    _required_protocol_cls = OOIProtocol
+    _light_enabled = False # default after initialization of device
+
+    def set_enable(self, enable=True):
+        self.protocol.send(0x03, int(enable))
+        self._light_enabled = bool(enable)
+
+    def is_enabled(self):
+        return self._light_enabled

--- a/src/seabreeze/pyseabreeze/protocol.py
+++ b/src/seabreeze/pyseabreeze/protocol.py
@@ -40,6 +40,7 @@ class OOIProtocol(ProtocolInterface):
     msgs = {code: functools.partial(struct.Struct(msg).pack, code) for code, msg in {
         0x01: '<B',    # OP_INITIALIZE
         0x02: '<BI',   # OP_ITIME
+        0x03: '<BH',   # set Strobe/Lamp enable Line
         0x05: '<BB',   # OP_GETINFO
         0x09: '<B',    # OP_REQUESTSPEC
         0x0A: '<BH',   # OP_SETTRIGMODE


### PR DESCRIPTION
 [pysb] light_enable feature for OOI protocol to switch lamp enable line (J2 pin 4) for continuous or strobe light

Hi Andreas,
this is my very low level implementation of light_enable. It would be more elegant to query the light status from the device via the "Query Status" command, but the returned information (and format!) is model specific. So I'm not sure whether to implement it as a feature or within spectrometer.py directly for the instrument.

Implementing as feature has the advantage of making it a dependency for e.g. light_enable...
