### PR TITLE
Added new udev rule for OceanOptics QE-Pro spectrometer

### DIFF
--- a/os_support/10-oceanoptics.rules
+++ b/os_support/10-oceanoptics.rules
@@ -1,8 +1,8 @@
 # udev rules file for Ocean Optics, Inc. spectrometers
 # ====================================================
 #
-# version: 2.1
-# updated: 2020-03-29
+# version: 2.2
+# updated: 2020-07-23
 # maintainer: Andreas Poehlmann <andreas@poehlmann.io>
 #
 # [info] Previous versions are missing this header.
@@ -14,6 +14,7 @@
 #   $ seabreeze_os_setup
 #
 # Changes:
+# - added support for QE-PRO class of OceanOptics spectrometers
 # - set MODE instead of group (Fedora doesn't use `plugdev`)
 # - match parent SUBSYSTEMS for compatibility with older udev versions
 # - match both actions 'add' and 'bind' (fixes https://github.com/systemd/systemd/issues/8221)

--- a/os_support/10-oceanoptics.rules
+++ b/os_support/10-oceanoptics.rules
@@ -70,6 +70,8 @@ ATTR{idVendor}=="2457", ATTR{idProduct}=="2000", SYMLINK+="jaz-%n", MODE:="0666"
 ATTR{idVendor}=="2457", ATTR{idProduct}=="4000", SYMLINK+="sts-%n", MODE:="0666"
 # Ocean Optics Inc. Spark spectrometer
 ATTR{idVendor}=="2457", ATTR{idProduct}=="4200", SYMLINK+="spark-%n", MODE:="0666"
+# OceanOptics Inc. QE-Pro Spectrometer
+ATTR{idVendor}=="2457",ATTR{idProduct}=="4004",SYMLINK+="qe-pro-%n",MODE:="0666"
 # Ocean Optics Inc. Centice Clear Shot II spectrometer
 ATTR{idVendor}=="184c", ATTR{idProduct}=="0000", SYMLINK+="clearshot2-%n", MODE:="0666"
 # unprogrammed EzUSB


### PR DESCRIPTION
New udev rule for the OceanOptics QE-Pro spectrometers (UV/Raman)