### PR TITLE
Basic support for HDX spectrometer

### DIFF
--- a/os_support/10-oceanoptics.rules
+++ b/os_support/10-oceanoptics.rules
@@ -81,5 +81,7 @@ ATTR{idVendor}=="0547", ATTR{idProduct}=="2131", SYMLINK+="ezUSB-%n", MODE:="066
 ATTR{idVendor}=="0547", ATTR{idProduct}=="2235", SYMLINK+="ezUSB-FX-%n", MODE:="0666"
 # unprogrammed EzUSB-FX2
 ATTR{idVendor}=="04b4", ATTR{idProduct}=="8613", SYMLINK+="ezUSB-FX2-%n", MODE:="0666"
+# Ocean Insight Inc. HDX spectrometer
+ATTR{idVendor}=="2457", ATTR{idProduct}=="2003", SYMLINK+="oceanhdx-%n", MODE:="0666"
 
 LABEL="oceanoptics_rules_end"

--- a/src/seabreeze/pyseabreeze/devices.py
+++ b/src/seabreeze/pyseabreeze/devices.py
@@ -256,6 +256,8 @@ class TriggerMode(enum.IntEnum):
     OBP_NORMAL = 0x00
     OBP_EXTERNAL = 0x01
     OBP_INTERNAL = 0x02
+    OBP_EDGE = 0x01
+    OBP_LEVEL = 0x03
 
     @classmethod
     def supported(cls, *mode_strings):
@@ -1034,4 +1036,34 @@ class SPARK(SeaBreezeDevice):
     feature_classes = (
         sbf.spectrometer.SeaBreezeSpectrometerFeatureSPARK,
         sbf.rawusb.SeaBreezeRawUSBBusAccessFeature,
+    )
+
+class HDX(SeaBreezeDevice):
+
+    model_name = 'HDX'
+
+    # communication config
+    transport = (USBTransport, )
+    usb_product_id = 0x2003
+    usb_endpoint_map = EndPointMap(ep_out=0x01, lowspeed_in=0x81,
+                                   highspeed_in=0x82, highspeed_in2=0x86)
+    usb_protocol = OBPProtocol
+
+    # spectrometer config
+    dark_pixel_indices = DarkPixelIndices.from_ranges()
+    integration_time_min = 6000
+    integration_time_max = 10000000
+    integration_time_base = 1
+    spectrum_num_pixel = 2068
+    spectrum_raw_length = (2068 * 2) + 64  # XXX: Metadata
+    spectrum_max_value = 65535
+    trigger_modes = TriggerMode.supported("OBP_NORMAL", "OBP_LEVEL", "OBP_EDGE", "DISABLED")
+
+    # features
+    feature_classes = (
+        sbf.spectrometer.SeaBreezeSpectrometerFeatureHDX, 
+        sbf.rawusb.SeaBreezeRawUSBBusAccessFeature,
+        sbf.nonlinearity.NonlinearityCoefficientsFeatureOBP,
+        #sbf.continuousstrobe.SeaBreezeContinuousStrobeFeatureOBP, # Implementation untested
+        #sbf.straylightcoefficients.StrayLightCoefficientsFeatureOBP, # Implementation untested
     )

--- a/src/seabreeze/pyseabreeze/features/spectrometer.py
+++ b/src/seabreeze/pyseabreeze/features/spectrometer.py
@@ -565,3 +565,14 @@ class SeaBreezeSpectrometerFeatureVENTANA(SeaBreezeSpectrometerFeatureOBP):
 
 class SeaBreezeSpectrometerFeatureSPARK(SeaBreezeSpectrometerFeatureOBP):
     pass
+
+class SeaBreezeSpectrometerFeatureHDX(SeaBreezeSpectrometerFeatureOBP):
+    def _get_spectrum_raw(self):
+        timeout = int(
+            self._integration_time_max * 1e-3
+            + self.protocol.transport.default_timeout_ms
+        )
+        # the message type is different than the default defined in the protocol,
+        # requires addition of a new message type in protocol to work
+        datastring = self.protocol.query(0x00101000, timeout_ms=timeout)
+        return numpy.fromstring(datastring, dtype=numpy.uint8)

--- a/src/seabreeze/pyseabreeze/protocol.py
+++ b/src/seabreeze/pyseabreeze/protocol.py
@@ -159,6 +159,7 @@ class OBPProtocol(ProtocolInterface):
         for code, msg in {
             0x00000100: "",  # GET_SERIAL
             0x00100928: "",  # GET_BUF_SPEC32_META
+            0x00101000: "",  # GET_RAW_SPECTRUM_NOW_HDX
             0x00101100: "",  # GET_RAW_SPECTRUM_NOW
             0x00110010: "<L",  # SET_ITIME_USEC
             0x00110110: "<B",  # SET_TRIG_MODE


### PR DESCRIPTION
This PR implements basic support for Ocean Insight Inc. HDX spectrometer in pyseabreeze backend.
So far acquiring spectrum and nonlinearity coefficients is tested working on WIN10, Python 3.8, LibUSB 1.0 and HDX UV-VIS.

Additional message type in protocol was required because HDX uses different addresses for raw spectra acquirement.

Resolves issue #60 