### PR TITLE
[pyseabreeze] add support for ADC1000-USB via USB

### DIFF
--- a/src/seabreeze/pyseabreeze/features/eeprom.py
+++ b/src/seabreeze/pyseabreeze/features/eeprom.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 from seabreeze.pyseabreeze.exceptions import SeaBreezeError
 from seabreeze.pyseabreeze.features._base import SeaBreezeFeature
+from seabreeze.pyseabreeze.protocol import ADCProtocol
 from seabreeze.pyseabreeze.protocol import OOIProtocol
 from seabreeze.pyseabreeze.types import PySeaBreezeProtocol
 
@@ -44,6 +45,44 @@ class SeaBreezeEEPromFeatureOOI(SeaBreezeEEPROMFeature):
     ) -> str:
         ret = SeaBreezeEEPromFeatureOOI._func_eeprom_read_raw(protocol, slot_number)
         data = ret[2 : ret[2:].index(0) + 2].decode("utf-8")
+        if not strip_zero_bytes:
+            return data
+        return data.rstrip("\x00")
+
+
+# ADC spectrometer interface implementation
+# =========================================
+#
+class SeaBreezeEEPromFeatureADC(SeaBreezeEEPROMFeature):
+    _required_protocol_cls = ADCProtocol
+
+    def eeprom_read_slot(self, slot_number: int, strip_zero_bytes: bool = False) -> str:
+        return self._func_eeprom_read_slot(
+            self.protocol, slot_number, strip_zero_bytes=strip_zero_bytes
+        )
+
+    @staticmethod
+    def _func_eeprom_read_raw(protocol: PySeaBreezeProtocol, slot_number: int) -> bytes:
+        protocol.send(0x05, slot_number)
+        ret = protocol.receive(size=17, mode="low_speed")
+        if ret[0] != 0x05 or ret[1] != int(slot_number) % 0xFF:
+            raise SeaBreezeError(f"read_eeprom_slot_raw: wrong answer: {ret!r}")
+        return ret
+
+    @classmethod
+    def _func_eeprom_read_slot(
+        cls,
+        protocol: PySeaBreezeProtocol,
+        slot_number: int,
+        *,
+        strip_zero_bytes: bool = False,
+    ) -> str:
+        ret = cls._func_eeprom_read_raw(protocol, slot_number)
+        try:
+            end = ret[2:].index(0) + 2
+        except ValueError:
+            end = len(ret) - 1
+        data = ret[2:end].decode("utf-8")
         if not strip_zero_bytes:
             return data
         return data.rstrip("\x00")


### PR DESCRIPTION
The ADC1000-USB is an older interface for S-series spectrometers (eg.
S2000) and has USB and serial connections.

This patch adds support for the interfacing with it via USB.

There are some similar ADC cards using different transports (eg. PCI,
PCMCIA), which I suspect use the same protocol, so this patch may set
the infrastructure to support those too.

Signed-off-by: Filipe Laíns <lains@riseup.net>