### PR TITLE
thermo_electric feature to the list of feature classes in NIRQUEST512

### DIFF
--- a/src/seabreeze/pyseabreeze/devices.py
+++ b/src/seabreeze/pyseabreeze/devices.py
@@ -803,6 +803,7 @@ class NIRQUEST512(SeaBreezeDevice):
         sbf.eeprom.SeaBreezeEEPromFeatureOOI,
         sbf.spectrometer.SeaBreezeSpectrometerFeatureNIRQUEST512,
         sbf.rawusb.SeaBreezeRawUSBBusAccessFeature,
+        sbf.thermoelectric.ThermoElectricFeatureOOI,
     )
 
 

--- a/src/seabreeze/pyseabreeze/features/spectrometer.py
+++ b/src/seabreeze/pyseabreeze/features/spectrometer.py
@@ -163,8 +163,7 @@ class SeaBreezeSpectrometerFeatureOOI(SeaBreezeSpectrometerFeature):
         ), "current impl requires USBTransport"
 
         timeout = int(
-            self._integration_time * 1e-3
-            + self.protocol.transport.default_timeout_ms
+            self._integration_time * 1e-3 + self.protocol.transport.default_timeout_ms
         )
         # noinspection PyProtectedMember
         tmp[:] = bytearray(
@@ -230,8 +229,7 @@ class SeaBreezeSpectrometerFeatureOOIFPGA4K(SeaBreezeSpectrometerFeatureOOIFPGA)
     def _get_spectrum_raw(self) -> NDArray[np.uint8]:
         tmp = numpy.empty((self._spectrum_raw_length,), dtype=numpy.uint8)
         timeout = int(
-            self._integration_time * 1e-3
-            + self.protocol.transport.default_timeout_ms
+            self._integration_time * 1e-3 + self.protocol.transport.default_timeout_ms
         )
         self.protocol.send(0x09)
         assert isinstance(
@@ -436,8 +434,7 @@ class SeaBreezeSpectrometerFeatureOBP(SeaBreezeSpectrometerFeature):
 
     def _get_spectrum_raw(self) -> NDArray[np.uint8]:
         timeout = int(
-            self._integration_time * 1e-3
-            + self.protocol.transport.default_timeout_ms
+            self._integration_time * 1e-3 + self.protocol.transport.default_timeout_ms
         )
         datastring = self.protocol.query(0x00101100, timeout_ms=timeout)
         return numpy.frombuffer(datastring, dtype=numpy.uint8)
@@ -563,8 +560,7 @@ class SeaBreezeSpectrometerFeatureSTS(SeaBreezeSpectrometerFeatureOBP):
 class SeaBreezeSpectrometerFeatureQEPRO(SeaBreezeSpectrometerFeatureOBP):
     def _get_spectrum_raw(self) -> NDArray[np.uint8]:
         timeout = int(
-            self._integration_time * 1e-3
-            + self.protocol.transport.default_timeout_ms
+            self._integration_time * 1e-3 + self.protocol.transport.default_timeout_ms
         )
         datastring = self.protocol.query(0x00100928, timeout_ms=timeout)
         return numpy.frombuffer(datastring, dtype=numpy.uint8)
@@ -587,8 +583,7 @@ class SeaBreezeSpectrometerFeatureSPARK(SeaBreezeSpectrometerFeatureOBP):
 class SeaBreezeSpectrometerFeatureHDX(SeaBreezeSpectrometerFeatureOBP):
     def _get_spectrum_raw(self) -> NDArray[np.uint8]:
         timeout = int(
-            self._integration_time * 1e-3
-            + self.protocol.transport.default_timeout_ms
+            self._integration_time * 1e-3 + self.protocol.transport.default_timeout_ms
         )
         # the message type is different than the default defined in the protocol,
         # requires addition of a new message type in protocol to work
@@ -613,8 +608,7 @@ class SeaBreezeSpectrometerFeatureADC(SeaBreezeSpectrometerFeatureOOI):
 class SeaBreezeSpectrometerFeatureSR2(SeaBreezeSpectrometerFeatureOBP):
     def _get_spectrum_raw(self) -> NDArray[np.uint8]:
         timeout = int(
-            self._integration_time * 1e-3
-            + self.protocol.transport.default_timeout_ms
+            self._integration_time * 1e-3 + self.protocol.transport.default_timeout_ms
         )
         datastring = self.protocol.query(0x000_01C_00, timeout_ms=timeout)
         return numpy.frombuffer(datastring, dtype=numpy.uint8)
@@ -655,8 +649,7 @@ class SeaBreezeSpectrometerFeatureSR2(SeaBreezeSpectrometerFeatureOBP):
 class SeaBreezeSpectrometerFeatureOBP2(SeaBreezeSpectrometerFeatureOBP):
     def _get_spectrum_raw(self) -> NDArray[np.uint8]:
         timeout = int(
-            self._integration_time * 1e-3
-            + self.protocol.transport.default_timeout_ms
+            self._integration_time * 1e-3 + self.protocol.transport.default_timeout_ms
         )
         datastring = self.protocol.query(0x000_01C_00, timeout_ms=timeout)
         return numpy.frombuffer(datastring, dtype=numpy.uint8)
@@ -696,6 +689,7 @@ class SeaBreezeSpectrometerFeatureOBP2(SeaBreezeSpectrometerFeatureOBP):
 
 class SeaBreezeSpectrometerFeatureSR4(SeaBreezeSpectrometerFeatureOBP2):
     pass
+
 
 class SeaBreezeSpectrometerFeatureST(SeaBreezeSpectrometerFeatureOBP2):
     pass

--- a/src/seabreeze/pyseabreeze/features/spectrometer.py
+++ b/src/seabreeze/pyseabreeze/features/spectrometer.py
@@ -107,6 +107,8 @@ class SeaBreezeSpectrometerFeatureOOI(SeaBreezeSpectrometerFeature):
         self._spectrum_max_value = kwargs["spectrum_max_value"]
         self._trigger_modes = kwargs["trigger_modes"]
 
+        self._integration_time = self._integration_time_max
+
     def set_trigger_mode(self, mode: int) -> None:
         if mode in self._trigger_modes:
             self.protocol.send(0x0A, mode)
@@ -117,6 +119,7 @@ class SeaBreezeSpectrometerFeatureOOI(SeaBreezeSpectrometerFeature):
         t_min = self._integration_time_min
         t_max = self._integration_time_max
         if t_min <= integration_time_micros < t_max:
+            self._integration_time = integration_time_micros
             i_time = int(integration_time_micros / self._integration_time_base)
             self.protocol.send(0x02, i_time)
         else:
@@ -160,7 +163,7 @@ class SeaBreezeSpectrometerFeatureOOI(SeaBreezeSpectrometerFeature):
         ), "current impl requires USBTransport"
 
         timeout = int(
-            self._integration_time_max * 1e-3
+            self._integration_time * 1e-3
             + self.protocol.transport.default_timeout_ms
         )
         # noinspection PyProtectedMember
@@ -227,7 +230,7 @@ class SeaBreezeSpectrometerFeatureOOIFPGA4K(SeaBreezeSpectrometerFeatureOOIFPGA)
     def _get_spectrum_raw(self) -> NDArray[np.uint8]:
         tmp = numpy.empty((self._spectrum_raw_length,), dtype=numpy.uint8)
         timeout = int(
-            self._integration_time_max * 1e-3
+            self._integration_time * 1e-3
             + self.protocol.transport.default_timeout_ms
         )
         self.protocol.send(0x09)
@@ -382,6 +385,8 @@ class SeaBreezeSpectrometerFeatureOBP(SeaBreezeSpectrometerFeature):
         self._spectrum_max_value = kwargs["spectrum_max_value"]
         self._trigger_modes = kwargs["trigger_modes"]
 
+        self._integration_time = self._integration_time_max
+
     def set_trigger_mode(self, mode: int) -> None:
         if mode in self._trigger_modes:
             self.protocol.send(0x00110110, mode, request_ack=True)
@@ -392,6 +397,7 @@ class SeaBreezeSpectrometerFeatureOBP(SeaBreezeSpectrometerFeature):
         t_min = self._integration_time_min
         t_max = self._integration_time_max
         if t_min <= integration_time_micros < t_max:
+            self._integration_time = integration_time_micros
             i_time = int(integration_time_micros / self._integration_time_base)
             self.protocol.send(0x00110010, i_time)
         else:
@@ -430,7 +436,7 @@ class SeaBreezeSpectrometerFeatureOBP(SeaBreezeSpectrometerFeature):
 
     def _get_spectrum_raw(self) -> NDArray[np.uint8]:
         timeout = int(
-            self._integration_time_max * 1e-3
+            self._integration_time * 1e-3
             + self.protocol.transport.default_timeout_ms
         )
         datastring = self.protocol.query(0x00101100, timeout_ms=timeout)
@@ -557,7 +563,7 @@ class SeaBreezeSpectrometerFeatureSTS(SeaBreezeSpectrometerFeatureOBP):
 class SeaBreezeSpectrometerFeatureQEPRO(SeaBreezeSpectrometerFeatureOBP):
     def _get_spectrum_raw(self) -> NDArray[np.uint8]:
         timeout = int(
-            self._integration_time_max * 1e-3
+            self._integration_time * 1e-3
             + self.protocol.transport.default_timeout_ms
         )
         datastring = self.protocol.query(0x00100928, timeout_ms=timeout)
@@ -581,7 +587,7 @@ class SeaBreezeSpectrometerFeatureSPARK(SeaBreezeSpectrometerFeatureOBP):
 class SeaBreezeSpectrometerFeatureHDX(SeaBreezeSpectrometerFeatureOBP):
     def _get_spectrum_raw(self) -> NDArray[np.uint8]:
         timeout = int(
-            self._integration_time_max * 1e-3
+            self._integration_time * 1e-3
             + self.protocol.transport.default_timeout_ms
         )
         # the message type is different than the default defined in the protocol,
@@ -607,7 +613,7 @@ class SeaBreezeSpectrometerFeatureADC(SeaBreezeSpectrometerFeatureOOI):
 class SeaBreezeSpectrometerFeatureSR2(SeaBreezeSpectrometerFeatureOBP):
     def _get_spectrum_raw(self) -> NDArray[np.uint8]:
         timeout = int(
-            self._integration_time_max * 1e-3
+            self._integration_time * 1e-3
             + self.protocol.transport.default_timeout_ms
         )
         datastring = self.protocol.query(0x000_01C_00, timeout_ms=timeout)
@@ -629,6 +635,7 @@ class SeaBreezeSpectrometerFeatureSR2(SeaBreezeSpectrometerFeatureOBP):
         t_min = self._integration_time_min
         t_max = self._integration_time_max
         if t_min <= integration_time_micros < t_max:
+            self._integration_time = integration_time_micros
             i_time = int(integration_time_micros / self._integration_time_base)
             self.protocol.send(0x000_00C_01, i_time)
         else:
@@ -645,10 +652,10 @@ class SeaBreezeSpectrometerFeatureSR2(SeaBreezeSpectrometerFeatureOBP):
         return sum(wl * (indices**i) for i, wl in enumerate(coeffs))  # type: ignore
 
 
-class SeaBreezeSpectrometerFeatureSR4(SeaBreezeSpectrometerFeatureOBP):
+class SeaBreezeSpectrometerFeatureOBP2(SeaBreezeSpectrometerFeatureOBP):
     def _get_spectrum_raw(self) -> NDArray[np.uint8]:
         timeout = int(
-            self._integration_time_max * 1e-3
+            self._integration_time * 1e-3
             + self.protocol.transport.default_timeout_ms
         )
         datastring = self.protocol.query(0x000_01C_00, timeout_ms=timeout)
@@ -670,6 +677,7 @@ class SeaBreezeSpectrometerFeatureSR4(SeaBreezeSpectrometerFeatureOBP):
         t_min = self._integration_time_min
         t_max = self._integration_time_max
         if t_min <= integration_time_micros < t_max:
+            self._integration_time = integration_time_micros
             i_time = int(integration_time_micros / self._integration_time_base)
             self.protocol.send(0x000_00C_01, i_time)
         else:
@@ -686,5 +694,8 @@ class SeaBreezeSpectrometerFeatureSR4(SeaBreezeSpectrometerFeatureOBP):
         return sum(wl * (indices**i) for i, wl in enumerate(coeffs))  # type: ignore
 
 
-class SeaBreezeSpectrometerFeatureST(SeaBreezeSpectrometerFeatureSR4):
+class SeaBreezeSpectrometerFeatureSR4(SeaBreezeSpectrometerFeatureOBP2):
+    pass
+
+class SeaBreezeSpectrometerFeatureST(SeaBreezeSpectrometerFeatureOBP2):
     pass


### PR DESCRIPTION
Hi,
Thanks for the great job of creating this repository. I was interfacing our OceanView spectrometers one by one in raw mode until I stumbled on this.
I added the thermo_electric feature to the list of feature classes in NIRQUEST512 after testing it with my spectrometer.

In theory, the strobe_lump feature should also work, but I don't know how to use it and no implementation exists yet in pyseabreeze.features for OOI protocol.

Another possible feature is the detector high gain mode, but 1) it doesn't seem to make any difference on my spectrometer, 2) I don't see anything in pyseabreeze.features that corresponds to this feature.

Also, here is result of running pytest:
```
================================================= test session starts =================================================
platform win32 -- Python 3.9.10, pytest-4.6.11, py-1.11.0, pluggy-0.13.1 -- C:\Users\raman\Documents\pydev\python-seabreeze\buildenv_py39_64\Scripts\python.exe
cachedir: .pytest_cache
rootdir: C:\Users\raman\Documents\pydev\python-seabreeze, inifile: pytest.ini
collected 28 items

tests/test_backends.py::test_seabreeze_installed PASSED                                                          [  3%]
tests/test_backends.py::test_seabreeze_wrong_backend_requested PASSED                                            [  7%]
tests/test_backends.py::test_seabreeze_any_backend_available[cseabreeze] PASSED                                  [ 10%]
tests/test_backends.py::test_seabreeze_any_backend_available[pyseabreeze] PASSED                                 [ 14%]
tests/test_backends.py::test_seabreeze_cseabreeze_backend_available PASSED                                       [ 17%]
tests/test_backends.py::test_seabreeze_pyseabreeze_backend_available PASSED                                      [ 21%]
tests/test_backends.py::test_seabreeze_cseabreeze_api_init PASSED                                                [ 25%]
tests/test_backends.py::test_seabreeze_pyseabreeze_api_init[any] PASSED                                          [ 28%]
tests/test_backends.py::test_seabreeze_pyseabreeze_api_init[openusb] PASSED                                      [ 32%]
tests/test_backends.py::test_seabreeze_pyseabreeze_api_init[libusb0] PASSED                                      [ 35%]
tests/test_backends.py::test_seabreeze_pyseabreeze_api_init[libusb1] PASSED                                      [ 39%]
tests/test_backends.py::test_seabreeze_compare_backend_feature_interfaces PASSED                                 [ 42%]
tests/test_protocol.py::test_pyseabreeze_protocol_messages PASSED                                                [ 46%]
tests/test_spectrometers.py::TestHardware::test_cant_find_serial[backend(any)] PASSED                            [ 50%]
tests/test_spectrometers.py::TestHardware::test_device_cleanup_on_exit[backend(any)] PASSED                      [ 53%]
tests/test_spectrometers.py::TestHardware::test_read_model[NIRQUEST512:NQ5200030-backend(any)] PASSED            [ 57%]
tests/test_spectrometers.py::TestHardware::test_read_serial_number[NIRQUEST512:NQ5200030-backend(any)] PASSED    [ 60%]
tests/test_spectrometers.py::TestHardware::test_crash_may_not_influence_following_tests[NIRQUEST512:NQ5200030-backend(any)] SKIPPED [ 64%]
tests/test_spectrometers.py::TestHardware::test_read_intensities[NIRQUEST512:NQ5200030-backend(any)] PASSED      [ 67%]
tests/test_spectrometers.py::TestHardware::test_correct_dark_pixels[NIRQUEST512:NQ5200030-backend(any)] PASSED   [ 71%]
tests/test_spectrometers.py::TestHardware::test_read_wavelengths[NIRQUEST512:NQ5200030-backend(any)] PASSED      [ 75%]
tests/test_spectrometers.py::TestHardware::test_read_spectrum[NIRQUEST512:NQ5200030-backend(any)] PASSED         [ 78%]
tests/test_spectrometers.py::TestHardware::test_max_intensity[NIRQUEST512:NQ5200030-backend(any)] PASSED         [ 82%]
tests/test_spectrometers.py::TestHardware::test_integration_time_limits[NIRQUEST512:NQ5200030-backend(any)] PASSED [ 85%]
tests/test_spectrometers.py::TestHardware::test_integration_time[NIRQUEST512:NQ5200030-backend(any)] PASSED      [ 89%]
tests/test_spectrometers.py::TestHardware::test_trigger_mode[NIRQUEST512:NQ5200030-backend(any)] PASSED          [ 92%]
tests/test_spectrometers.py::TestHardware::test_trigger_mode_wrong[NIRQUEST512:NQ5200030-backend(any)] PASSED    [ 96%]
tests/test_spectrometers.py::TestHardware::test_list_devices_dont_close_opened_devices[backend(any)] PASSED      [100%]

================================================== warnings summary ===================================================
tests/test_spectrometers.py::TestHardware::test_correct_dark_pixels[NIRQUEST512:NQ5200030-backend(any)]
  C:\Users\raman\Documents\pydev\python-seabreeze\buildenv_py39_64\lib\site-packages\numpy\core\fromnumeric.py:3504: RuntimeWarning: Mean of empty slice.
    return _methods._mean(a, axis=axis, dtype=dtype,

tests/test_spectrometers.py::TestHardware::test_correct_dark_pixels[NIRQUEST512:NQ5200030-backend(any)]
  C:\Users\raman\Documents\pydev\python-seabreeze\buildenv_py39_64\lib\site-packages\numpy\core\_methods.py:129: RuntimeWarning: invalid value encountered in scalar divide
    ret = ret.dtype.type(ret / rcount)

-- Docs: https://docs.pytest.org/en/latest/warnings.html
=============================================== short test summary info ===============================================
SKIPPED [1] tests\test_spectrometers.py:237: FIXME: TEST BREAKS OTHER TESTS ON WINDOWS
================================== 27 passed, 1 skipped, 2 warnings in 7.24 seconds ===================================
```