### PR TITLE
Add SR6 support

### DIFF
--- a/os_support/10-oceanoptics.rules
+++ b/os_support/10-oceanoptics.rules
@@ -92,5 +92,7 @@ ATTR{idVendor}=="0999", ATTR{idProduct}=="1000", SYMLINK+="st-%n", MODE:="0666"
 ATTR{idVendor}=="0999", ATTR{idProduct}=="1001", SYMLINK+="sr2-%n", MODE:="0666"
 # Ocean Insight Inc. SR4 spectrometer
 ATTR{idVendor}=="0999", ATTR{idProduct}=="1002", SYMLINK+="sr4-%n", MODE:="0666"
+# Ocean Insight Inc. SR6 Spectrometer
+ATTR{idVendor}=="0999", ATTR{idProduct}=="1005", SYMLINK+="sr6-%n", MODE:="0666"
 
 LABEL="oceanoptics_rules_end"

--- a/src/seabreeze/pyseabreeze/devices.py
+++ b/src/seabreeze/pyseabreeze/devices.py
@@ -1249,7 +1249,28 @@ class SR4(SeaBreezeDevice):
 
     # features
     feature_classes = (sbf.spectrometer.SeaBreezeSpectrometerFeatureSR4,)
+class SR6(SeaBreezeDevice):
+    model_name = "SR6"
 
+    # communication config
+    transport = (USBTransport,)
+    usb_vendor_id = 0x0999
+    usb_product_id = 0x1005
+    usb_endpoint_map = EndPointMap(ep_out=0x01, highspeed_in=0x81)
+    usb_protocol = OBP2Protocol
+
+    # spectrometer config
+    dark_pixel_indices = DarkPixelIndices.from_ranges()
+    integration_time_min = 7200  # 7.2ms ?
+    integration_time_max = 5000000  # 5s ? per website
+    integration_time_base = 1
+    spectrum_num_pixel = 3648
+    spectrum_raw_length = (3648 * 2) + 32  # XXX: Metadata
+    spectrum_max_value = 65535
+    trigger_modes = TriggerMode.supported("OBP_NORMAL")
+
+    # features
+    feature_classes = (sbf.spectrometer.SeaBreezeSpectrometerFeatureSR4,)
 
 class ST(SeaBreezeDevice):
     model_name = "ST"

--- a/src/seabreeze/pyseabreeze/devices.py
+++ b/src/seabreeze/pyseabreeze/devices.py
@@ -1270,7 +1270,7 @@ class SR6(SeaBreezeDevice):
     trigger_modes = TriggerMode.supported("OBP_NORMAL")
 
     # features
-    feature_classes = (sbf.spectrometer.SeaBreezeSpectrometerFeatureSR4,)
+    feature_classes = (sbf.spectrometer.SeaBreezeSpectrometerFeatureSR6,)
 
 class ST(SeaBreezeDevice):
     model_name = "ST"

--- a/src/seabreeze/pyseabreeze/devices.py
+++ b/src/seabreeze/pyseabreeze/devices.py
@@ -1239,8 +1239,8 @@ class SR4(SeaBreezeDevice):
 
     # spectrometer config
     dark_pixel_indices = DarkPixelIndices.from_ranges()
-    integration_time_min = 6000  # ???
-    integration_time_max = 10000000  # ???
+    integration_time_min = 3800 #3.8ms
+    integration_time_max = 10000000 #10s
     integration_time_base = 1
     spectrum_num_pixel = 3648
     spectrum_raw_length = (3648 * 2) + 32  # XXX: Metadata
@@ -1261,11 +1261,11 @@ class SR6(SeaBreezeDevice):
 
     # spectrometer config
     dark_pixel_indices = DarkPixelIndices.from_ranges()
-    integration_time_min = 7200  # 7.2ms ?
-    integration_time_max = 5000000  # 5s ? per website
+    integration_time_min = 7200  # 7.2ms 
+    integration_time_max = 5000000  # 5s 
     integration_time_base = 1
-    spectrum_num_pixel = 3648
-    spectrum_raw_length = (3648 * 2) + 32  # XXX: Metadata
+    spectrum_num_pixel = 2048
+    spectrum_raw_length = (2048 * 2) + 32  # XXX: Metadata
     spectrum_max_value = 65535
     trigger_modes = TriggerMode.supported("OBP_NORMAL")
 

--- a/src/seabreeze/pyseabreeze/devices.py
+++ b/src/seabreeze/pyseabreeze/devices.py
@@ -1239,8 +1239,8 @@ class SR4(SeaBreezeDevice):
 
     # spectrometer config
     dark_pixel_indices = DarkPixelIndices.from_ranges()
-    integration_time_min = 3800 #3.8ms
-    integration_time_max = 10000000 #10s
+    integration_time_min = 3800  # 3.8ms
+    integration_time_max = 10000000  # 10s
     integration_time_base = 1
     spectrum_num_pixel = 3648
     spectrum_raw_length = (3648 * 2) + 32  # XXX: Metadata
@@ -1249,6 +1249,8 @@ class SR4(SeaBreezeDevice):
 
     # features
     feature_classes = (sbf.spectrometer.SeaBreezeSpectrometerFeatureSR4,)
+
+
 class SR6(SeaBreezeDevice):
     model_name = "SR6"
 
@@ -1261,8 +1263,8 @@ class SR6(SeaBreezeDevice):
 
     # spectrometer config
     dark_pixel_indices = DarkPixelIndices.from_ranges()
-    integration_time_min = 7200  # 7.2ms 
-    integration_time_max = 5000000  # 5s 
+    integration_time_min = 7200  # 7.2ms
+    integration_time_max = 5000000  # 5s
     integration_time_base = 1
     spectrum_num_pixel = 2048
     spectrum_raw_length = (2048 * 2) + 32  # XXX: Metadata
@@ -1271,6 +1273,7 @@ class SR6(SeaBreezeDevice):
 
     # features
     feature_classes = (sbf.spectrometer.SeaBreezeSpectrometerFeatureSR6,)
+
 
 class ST(SeaBreezeDevice):
     model_name = "ST"

--- a/src/seabreeze/pyseabreeze/features/spectrometer.py
+++ b/src/seabreeze/pyseabreeze/features/spectrometer.py
@@ -644,6 +644,46 @@ class SeaBreezeSpectrometerFeatureSR2(SeaBreezeSpectrometerFeatureOBP):
         # and generate the wavelength array
         indices = numpy.arange(self._spectrum_length, dtype=numpy.float64)
         return sum(wl * (indices**i) for i, wl in enumerate(coeffs))  # type: ignore
+    
+class SeaBreezeSpectrometerFeatureSR4(SeaBreezeSpectrometerFeatureOBP):
+    def _get_spectrum_raw(self) -> NDArray[np.uint8]:
+        timeout = int(
+            self._integration_time * 1e-3 + self.protocol.transport.default_timeout_ms
+        )
+        datastring = self.protocol.query(0x000_01C_00, timeout_ms=timeout)
+        return numpy.frombuffer(datastring, dtype=numpy.uint8)
+
+    def get_intensities(self) -> NDArray[np.float_]:
+        tmp = self._get_spectrum_raw()
+        # 32byte metadata block at beginning
+        ret = tmp[32:].view(numpy.dtype("<H")).astype(numpy.double)
+        return ret * self._normalization_value
+
+    def set_trigger_mode(self, mode: int) -> None:
+        if mode in self._trigger_modes:
+            self.protocol.send(0x000_00D_01, mode, request_ack=True)
+        else:
+            raise SeaBreezeError("Only supports: %s" % str(self._trigger_modes))
+
+    def set_integration_time_micros(self, integration_time_micros: int) -> None:
+        t_min = self._integration_time_min
+        t_max = self._integration_time_max
+        if t_min <= integration_time_micros < t_max:
+            self._integration_time = integration_time_micros
+            i_time = int(integration_time_micros / self._integration_time_base)
+            self.protocol.send(0x000_00C_01, i_time)
+        else:
+            raise SeaBreezeError(f"Integration not in [{t_min:d}, {t_max:d}]")
+
+    def get_wavelengths(self) -> NDArray[np.float_]:
+        data = self.protocol.query(0x000_011_00)
+        num_coeffs = len(data) // 4
+        assert len(data) % 4 == 0  # ???
+        assert num_coeffs > 1  # ???
+        coeffs = struct.unpack("<" + "f" * num_coeffs, data)[1:]
+        # and generate the wavelength array
+        indices = numpy.arange(self._spectrum_length, dtype=numpy.float64)
+        return sum(wl * (indices**i) for i, wl in enumerate(coeffs))  # type: ignore
 
 
 class SeaBreezeSpectrometerFeatureOBP2(SeaBreezeSpectrometerFeatureOBP):

--- a/src/seabreeze/pyseabreeze/features/spectrometer.py
+++ b/src/seabreeze/pyseabreeze/features/spectrometer.py
@@ -690,6 +690,7 @@ class SeaBreezeSpectrometerFeatureOBP2(SeaBreezeSpectrometerFeatureOBP):
 class SeaBreezeSpectrometerFeatureSR4(SeaBreezeSpectrometerFeatureOBP2):
     pass
 
+
 class SeaBreezeSpectrometerFeatureSR6(SeaBreezeSpectrometerFeatureOBP2):
     pass
 


### PR DESCRIPTION
Adding support for SR6 spectrometer. Passes pytest suite without dark count support
changed SR4 integration time limits to reflect datasheet (untested)