### PR TITLE
Corrected integration time values for the OceanFX

### DIFF
--- a/src/libseabreeze/src/vendors/OceanOptics/features/spectrometer/FlameXSpectrometerFeature.cpp
+++ b/src/libseabreeze/src/vendors/OceanOptics/features/spectrometer/FlameXSpectrometerFeature.cpp
@@ -50,9 +50,9 @@ using namespace std;
 /* This value should have been located in constants file for non-probable */
 /* spectrometer characteristics, not buried here */
 
-const long FlameXSpectrometerFeature::INTEGRATION_TIME_MINIMUM = 1000;
-const long FlameXSpectrometerFeature::INTEGRATION_TIME_MAXIMUM = 60000000;
-const long FlameXSpectrometerFeature::INTEGRATION_TIME_INCREMENT = 1000;
+const long FlameXSpectrometerFeature::INTEGRATION_TIME_MINIMUM = 10;
+const long FlameXSpectrometerFeature::INTEGRATION_TIME_MAXIMUM = 10000000;
+const long FlameXSpectrometerFeature::INTEGRATION_TIME_INCREMENT = 1;
 const long FlameXSpectrometerFeature::INTEGRATION_TIME_BASE = 1;
 
 FlameXSpectrometerFeature::FlameXSpectrometerFeature(IntrospectionFeature *introspection, FlameXFastBufferFeature *fastBuffer ) {


### PR DESCRIPTION
The stored values for the integration time of the OceanFX in libseabreeze were not correct.
I corrected the values with this minor change.