### PR TITLE
Basic HR2 support

### DIFF
--- a/os_support/10-oceanoptics.rules
+++ b/os_support/10-oceanoptics.rules
@@ -1,8 +1,8 @@
 # udev rules file for Ocean Optics, Inc. spectrometers
 # ====================================================
 #
-# version: 2.6
-# updated: 2024-01-24
+# version: 2.7
+# updated: 2024-05-29
 # maintainer: Andreas Poehlmann <andreas@poehlmann.io>
 #
 # [info] Previous versions are missing this header.
@@ -14,6 +14,7 @@
 #   $ seabreeze_os_setup
 #
 # Changes:
+# - [2.7] added support for HR2 spectrometer
 # - [2.6] added support for SR6 spectrometer
 # - [2.5] added support for SR2 spectrometer
 # - [2.4] added support for SR4 spectrometer

--- a/os_support/10-oceanoptics.rules
+++ b/os_support/10-oceanoptics.rules
@@ -95,5 +95,7 @@ ATTR{idVendor}=="0999", ATTR{idProduct}=="1001", SYMLINK+="sr2-%n", MODE:="0666"
 ATTR{idVendor}=="0999", ATTR{idProduct}=="1002", SYMLINK+="sr4-%n", MODE:="0666"
 # Ocean Insight Inc. SR6 Spectrometer
 ATTR{idVendor}=="0999", ATTR{idProduct}=="1005", SYMLINK+="sr6-%n", MODE:="0666"
+# Ocean Insight Inc. HR2 Spectrometer
+ATTR{idVendor}=="0999", ATTR{idProduct}=="1003", SYMLINK+="hr2-%n", MODE:="0666"
 
 LABEL="oceanoptics_rules_end"

--- a/src/seabreeze/pyseabreeze/devices.py
+++ b/src/seabreeze/pyseabreeze/devices.py
@@ -1276,6 +1276,30 @@ class SR6(SeaBreezeDevice):
     feature_classes = (sbf.spectrometer.SeaBreezeSpectrometerFeatureSR6,)
 
 
+class HR2(SeaBreezeDevice):
+    model_name = "HR2"
+
+    # communication config
+    transport = (USBTransport,)
+    usb_vendor_id = 0x0999
+    usb_product_id = 0x1003
+    usb_endpoint_map = EndPointMap(ep_out=0x01, highspeed_in=0x81)
+    usb_protocol = OBP2Protocol
+
+    # spectrometer config
+    dark_pixel_indices = DarkPixelIndices.from_ranges()
+    integration_time_min = 1  # 1 us
+    integration_time_max = 2000000  # 2 s
+    integration_time_base = 1
+    spectrum_num_pixel = 2110
+    spectrum_raw_length = (2110 * 2) + 32  # XXX: Metadata
+    spectrum_max_value = 65535
+    trigger_modes = TriggerMode.supported("OBP_NORMAL")
+
+    # features
+    feature_classes = (sbf.spectrometer.SeaBreezeSpectrometerFeatureHR2,)
+
+
 class ST(SeaBreezeDevice):
     model_name = "ST"
 

--- a/src/seabreeze/pyseabreeze/features/spectrometer.py
+++ b/src/seabreeze/pyseabreeze/features/spectrometer.py
@@ -697,3 +697,46 @@ class SeaBreezeSpectrometerFeatureSR6(SeaBreezeSpectrometerFeatureOBP2):
 
 class SeaBreezeSpectrometerFeatureST(SeaBreezeSpectrometerFeatureOBP2):
     pass
+
+class SeaBreezeSpectrometerFeatureHR2(SeaBreezeSpectrometerFeatureOBP):
+    def _get_spectrum_raw(self) -> NDArray[np.uint8]:
+        timeout = int(
+            self._integration_time * 1e-3 + self.protocol.transport.default_timeout_ms
+        )
+        datastring = self.protocol.query(0x000_01C_00, timeout_ms=timeout)
+        return numpy.frombuffer(datastring, dtype=numpy.uint8)
+
+    def get_intensities(self) -> NDArray[np.float_]:
+        tmp = self._get_spectrum_raw()
+        # 32byte metadata block at beginning
+        ret = tmp[32:].view(numpy.dtype("<H")).astype(numpy.double)
+        return ret * self._normalization_value
+
+    def set_trigger_mode(self, mode: int) -> None:
+        if mode in self._trigger_modes:
+            self.protocol.send(0x000_00D_01, mode, request_ack=True)
+        else:
+            raise SeaBreezeError("Only supports: %s" % str(self._trigger_modes))
+
+    def set_integration_time_micros(self, integration_time_micros: int) -> None:
+        t_min = self._integration_time_min
+        t_max = self._integration_time_max
+        if t_min <= integration_time_micros < t_max:
+            self._integration_time = integration_time_micros
+            i_time = int(integration_time_micros / self._integration_time_base)
+            self.protocol.send(0x000_00C_01, i_time)
+        else:
+            raise SeaBreezeError(f"Integration not in [{t_min:d}, {t_max:d}]")
+
+    def get_wavelengths(self) -> NDArray[np.float_]:
+        data = self.protocol.query(0x000_011_00)
+        num_coeffs = len(data) // 4
+        assert len(data) % 4 == 0  # ???
+        assert num_coeffs > 1  # ???
+        coeffs = struct.unpack("<" + "f" * num_coeffs, data)[1:]
+        # and generate the wavelength array
+        indices = numpy.arange(self._spectrum_length, dtype=numpy.float64)
+        return sum(wl * (indices**i) for i, wl in enumerate(coeffs))  # type: ignore
+
+class SeaBreezeSpectrometerFeatureHR2(SeaBreezeSpectrometerFeatureOBP2):
+    pass

--- a/src/seabreeze/pyseabreeze/features/spectrometer.py
+++ b/src/seabreeze/pyseabreeze/features/spectrometer.py
@@ -698,6 +698,7 @@ class SeaBreezeSpectrometerFeatureSR6(SeaBreezeSpectrometerFeatureOBP2):
 class SeaBreezeSpectrometerFeatureST(SeaBreezeSpectrometerFeatureOBP2):
     pass
 
+
 class SeaBreezeSpectrometerFeatureHR2(SeaBreezeSpectrometerFeatureOBP):
     def _get_spectrum_raw(self) -> NDArray[np.uint8]:
         timeout = int(
@@ -737,6 +738,7 @@ class SeaBreezeSpectrometerFeatureHR2(SeaBreezeSpectrometerFeatureOBP):
         # and generate the wavelength array
         indices = numpy.arange(self._spectrum_length, dtype=numpy.float64)
         return sum(wl * (indices**i) for i, wl in enumerate(coeffs))  # type: ignore
+
 
 class SeaBreezeSpectrometerFeatureHR2(SeaBreezeSpectrometerFeatureOBP2):
     pass

--- a/src/seabreeze/pyseabreeze/features/spectrometer.py
+++ b/src/seabreeze/pyseabreeze/features/spectrometer.py
@@ -738,7 +738,3 @@ class SeaBreezeSpectrometerFeatureHR2(SeaBreezeSpectrometerFeatureOBP):
         # and generate the wavelength array
         indices = numpy.arange(self._spectrum_length, dtype=numpy.float64)
         return sum(wl * (indices**i) for i, wl in enumerate(coeffs))  # type: ignore
-
-
-class SeaBreezeSpectrometerFeatureHR2(SeaBreezeSpectrometerFeatureOBP2):
-    pass


### PR DESCRIPTION
Here is a most basic HR2 support to pyseabreeze.
-) Updated udev rules with appropriate PID.
-) Copied and adapted the SR2 spectrometer class. 

Tested basic functionality:
-) Spectrometer is now found by seabreeze.
-) Acquisition of a spectrum succeeds.

Passes pytest, without dark counts like the SR2 class this code is derived from.

```
============================================================================================================== test session starts ===============================================================================================================
platform linux -- Python 3.12.3, pytest-8.2.1, pluggy-1.5.0 -- /home/peter/.local/venvs/pd12/bin/python
cachedir: .pytest_cache
rootdir: /home/peter/development/python-seabreeze
configfile: pytest.ini
plugins: anyio-4.2.0
collected 28 items

tests/test_backends.py::test_seabreeze_installed PASSED                                                                                                                                                                                    [  3%]
tests/test_backends.py::test_seabreeze_wrong_backend_requested PASSED                                                                                                                                                                      [  7%]
tests/test_backends.py::test_seabreeze_any_backend_available[cseabreeze] PASSED                                                                                                                                                            [ 10%]
tests/test_backends.py::test_seabreeze_any_backend_available[pyseabreeze] PASSED                                                                                                                                                           [ 14%]
tests/test_backends.py::test_seabreeze_cseabreeze_backend_available PASSED                                                                                                                                                                 [ 17%]
tests/test_backends.py::test_seabreeze_pyseabreeze_backend_available PASSED                                                                                                                                                                [ 21%]
tests/test_backends.py::test_seabreeze_cseabreeze_api_init PASSED                                                                                                                                                                          [ 25%]
tests/test_backends.py::test_seabreeze_pyseabreeze_api_init[any] PASSED                                                                                                                                                                    [ 28%]
tests/test_backends.py::test_seabreeze_pyseabreeze_api_init[openusb] PASSED                                                                                                                                                                [ 32%]
tests/test_backends.py::test_seabreeze_pyseabreeze_api_init[libusb0] PASSED                                                                                                                                                                [ 35%]
tests/test_backends.py::test_seabreeze_pyseabreeze_api_init[libusb1] PASSED                                                                                                                                                                [ 39%]
tests/test_backends.py::test_seabreeze_compare_backend_feature_interfaces PASSED                                                                                                                                                           [ 42%]
tests/test_protocol.py::test_pyseabreeze_protocol_messages PASSED                                                                                                                                                                          [ 46%]
tests/test_spectrometers.py::TestHardware::test_cant_find_serial[backend(any)] PASSED                                                                                                                                                      [ 50%]
tests/test_spectrometers.py::TestHardware::test_device_cleanup_on_exit[backend(any)] PASSED                                                                                                                                                [ 53%]
tests/test_spectrometers.py::TestHardware::test_read_model[HR2:HR200451-backend(any)] PASSED                                                                                                                                               [ 57%]
tests/test_spectrometers.py::TestHardware::test_read_serial_number[HR2:HR200451-backend(any)] PASSED                                                                                                                                       [ 60%]
tests/test_spectrometers.py::TestHardware::test_crash_may_not_influence_following_tests[HR2:HR200451-backend(any)] XFAIL (check if following tests work after crash)                                                                       [ 64%]
tests/test_spectrometers.py::TestHardware::test_read_intensities[HR2:HR200451-backend(any)] PASSED                                                                                                                                         [ 67%]
tests/test_spectrometers.py::TestHardware::test_correct_dark_pixels[HR2:HR200451-backend(any)] SKIPPED (does not support dark counts)                                                                                                      [ 71%]
tests/test_spectrometers.py::TestHardware::test_read_wavelengths[HR2:HR200451-backend(any)] PASSED                                                                                                                                         [ 75%]
tests/test_spectrometers.py::TestHardware::test_read_spectrum[HR2:HR200451-backend(any)] PASSED                                                                                                                                            [ 78%]
tests/test_spectrometers.py::TestHardware::test_max_intensity[HR2:HR200451-backend(any)] PASSED                                                                                                                                            [ 82%]
tests/test_spectrometers.py::TestHardware::test_integration_time_limits[HR2:HR200451-backend(any)] PASSED                                                                                                                                  [ 85%]
tests/test_spectrometers.py::TestHardware::test_integration_time[HR2:HR200451-backend(any)] PASSED                                                                                                                                         [ 89%]
tests/test_spectrometers.py::TestHardware::test_trigger_mode[HR2:HR200451-backend(any)] PASSED                                                                                                                                             [ 92%]
tests/test_spectrometers.py::TestHardware::test_trigger_mode_wrong[HR2:HR200451-backend(any)] PASSED                                                                                                                                       [ 96%]
tests/test_spectrometers.py::TestHardware::test_list_devices_dont_close_opened_devices[backend(any)] PASSED                                                                                                                                [100%]

============================================================================================================ short test summary info =============================================================================================================
SKIPPED [1] tests/test_spectrometers.py:265: does not support dark counts
=================================================================================================== 26 passed, 1 skipped, 1 xfailed in 25.08s ====================================================================================================
```