### PR TITLE
Proof-of-concept: Add network support (IPv4Transport)

### DIFF
--- a/src/seabreeze/backends.py
+++ b/src/seabreeze/backends.py
@@ -61,6 +61,9 @@ def use(
         if "pyusb_backend" in kwargs:
             pyusb_backend = kwargs.pop("pyusb_backend")
             BackendConfig.api_kwargs["pyusb_backend"] = pyusb_backend
+        if "network_adapter" in kwargs:
+            network_adapter = kwargs.pop("network_adapter")
+            BackendConfig.api_kwargs["network_adapter"] = network_adapter
     if kwargs:
         raise TypeError(
             f"unknown keyword arguments {set(kwargs)!r} for backend {backend!r}"

--- a/src/seabreeze/pyseabreeze/api.py
+++ b/src/seabreeze/pyseabreeze/api.py
@@ -97,8 +97,7 @@ class SeaBreezeAPI(_SeaBreezeAPIProtocol):
         self, device_type: str, ip_address: str, port: int
     ) -> None:
         """add ipv4 device location"""
-        # IPV4Transport.register_device(device_type, ip_address, port)
-        raise NotImplementedError("ipv4 communication not implemented for pyseabreeze")
+        IPv4Transport.register_model(device_type, ipv4_address=ip_address, ipv4_port=port)
 
     def list_devices(self) -> list[_SeaBreezeDevice]:
         """returns available SeaBreezeDevices

--- a/src/seabreeze/pyseabreeze/api.py
+++ b/src/seabreeze/pyseabreeze/api.py
@@ -51,9 +51,7 @@ def _seabreeze_device_factory(
     dev : SeaBreezeDevice
     """
     global _seabreeze_device_instance_registry
-    if not isinstance(device, USBTransportHandle) and not isinstance(
-        device, IPv4TransportHandle
-    ):
+    if not isinstance(device, (USBTransportHandle, IPv4TransportHandle)):
         raise TypeError(
             f"needs to be instance of USBTransportHandle or IPv4TransportHandle and not '{type(device)}'"
         )

--- a/src/seabreeze/pyseabreeze/api.py
+++ b/src/seabreeze/pyseabreeze/api.py
@@ -141,11 +141,10 @@ class SeaBreezeAPI(_SeaBreezeAPIProtocol):
                 # opening the device will populate its serial number
                 try:
                     dev.open()
-                except Exception:
-                    # TODO specify expected exception
+                except RuntimeError:
                     raise
-                # else:
-                #    dev.close()
+                else:
+                    dev.close()
             devices.append(dev)  # type: ignore
         return devices
 

--- a/src/seabreeze/pyseabreeze/api.py
+++ b/src/seabreeze/pyseabreeze/api.py
@@ -103,7 +103,9 @@ class SeaBreezeAPI(_SeaBreezeAPIProtocol):
         self, device_type: str, ip_address: str, port: int
     ) -> None:
         """add ipv4 device location"""
-        IPv4Transport.register_model(device_type, ipv4_address=ip_address, ipv4_port=port)
+        IPv4Transport.register_model(
+            device_type, ipv4_address=ip_address, ipv4_port=port
+        )
 
     def list_devices(self) -> list[_SeaBreezeDevice]:
         """returns available SeaBreezeDevices

--- a/src/seabreeze/pyseabreeze/devices.py
+++ b/src/seabreeze/pyseabreeze/devices.py
@@ -313,7 +313,11 @@ class SeaBreezeDevice(metaclass=_SeaBreezeDeviceMeta):
             raise SeaBreezeError(
                 "Don't instantiate SeaBreezeDevice directly. Use `SeabreezeAPI.list_devices()`."
             )
-        for transport in {USBTransport, IPv4Transport}:
+        transports: list[type[PySeaBreezeTransport[Any]]] = [
+            IPv4Transport,
+            USBTransport,
+        ]
+        for transport in transports:
             supported_model = transport.supported_model(raw_device)
             if supported_model is not None:
                 break

--- a/src/seabreeze/pyseabreeze/devices.py
+++ b/src/seabreeze/pyseabreeze/devices.py
@@ -1147,16 +1147,14 @@ class HDX(SeaBreezeDevice):
     model_name = "HDX"
 
     # communication config
-    transport = (IPv4Transport, )
-    #usb_vendor_id = 0x2457
-    #usb_product_id = 0x2003
-    #usb_endpoint_map = EndPointMap(
-    #    ep_out=0x01, lowspeed_in=0x81, highspeed_in=0x82, highspeed_in2=0x86
-    #)
-    #usb_protocol = OBPProtocol
+    transport = (IPv4Transport, USBTransport, )
+    usb_vendor_id = 0x2457
+    usb_product_id = 0x2003
+    usb_endpoint_map = EndPointMap(
+        ep_out=0x01, lowspeed_in=0x81, highspeed_in=0x82, highspeed_in2=0x86
+    )
+    usb_protocol = OBPProtocol
 
-    ipv4_address = '192.168.254.254'
-    ipv4_port = 57357
     ipv4_protocol = OBPProtocol
 
     # spectrometer config

--- a/src/seabreeze/pyseabreeze/devices.py
+++ b/src/seabreeze/pyseabreeze/devices.py
@@ -21,6 +21,7 @@ from seabreeze.pyseabreeze.protocol import OBP2Protocol
 from seabreeze.pyseabreeze.protocol import OBPProtocol
 from seabreeze.pyseabreeze.protocol import OOIProtocol
 from seabreeze.pyseabreeze.transport import USBTransport
+from seabreeze.pyseabreeze.transport import IPv4Transport
 from seabreeze.pyseabreeze.types import PySeaBreezeTransport
 from seabreeze.types import SeaBreezeFeatureAccessor
 
@@ -312,7 +313,7 @@ class SeaBreezeDevice(metaclass=_SeaBreezeDeviceMeta):
             raise SeaBreezeError(
                 "Don't instantiate SeaBreezeDevice directly. Use `SeabreezeAPI.list_devices()`."
             )
-        for transport in {USBTransport}:
+        for transport in {USBTransport, IPv4Transport}:
             supported_model = transport.supported_model(raw_device)
             if supported_model is not None:
                 break
@@ -365,7 +366,7 @@ class SeaBreezeDevice(metaclass=_SeaBreezeDeviceMeta):
         return f"<SeaBreezeDevice {self.model}:{self.serial_number}>"
 
     def open(self) -> None:
-        """open the spectrometer usb connection
+        """open the spectrometer connection
 
         Returns
         -------

--- a/src/seabreeze/pyseabreeze/devices.py
+++ b/src/seabreeze/pyseabreeze/devices.py
@@ -1147,7 +1147,10 @@ class HDX(SeaBreezeDevice):
     model_name = "HDX"
 
     # communication config
-    transport = (IPv4Transport, USBTransport, )
+    transport = (
+        IPv4Transport,
+        USBTransport,
+    )
     usb_vendor_id = 0x2457
     usb_product_id = 0x2003
     usb_endpoint_map = EndPointMap(

--- a/src/seabreeze/pyseabreeze/devices.py
+++ b/src/seabreeze/pyseabreeze/devices.py
@@ -1147,13 +1147,17 @@ class HDX(SeaBreezeDevice):
     model_name = "HDX"
 
     # communication config
-    transport = (USBTransport,)
-    usb_vendor_id = 0x2457
-    usb_product_id = 0x2003
-    usb_endpoint_map = EndPointMap(
-        ep_out=0x01, lowspeed_in=0x81, highspeed_in=0x82, highspeed_in2=0x86
-    )
-    usb_protocol = OBPProtocol
+    transport = (IPv4Transport, )
+    #usb_vendor_id = 0x2457
+    #usb_product_id = 0x2003
+    #usb_endpoint_map = EndPointMap(
+    #    ep_out=0x01, lowspeed_in=0x81, highspeed_in=0x82, highspeed_in2=0x86
+    #)
+    #usb_protocol = OBPProtocol
+
+    ipv4_address = '192.168.254.254'
+    ipv4_port = 57357
+    ipv4_protocol = OBPProtocol
 
     # spectrometer config
     dark_pixel_indices = DarkPixelIndices.from_ranges()

--- a/src/seabreeze/pyseabreeze/devices.py
+++ b/src/seabreeze/pyseabreeze/devices.py
@@ -1174,6 +1174,7 @@ class HDX(SeaBreezeDevice):
         sbf.spectrometer.SeaBreezeSpectrometerFeatureHDX,
         sbf.rawusb.SeaBreezeRawUSBBusAccessFeature,
         sbf.nonlinearity.NonlinearityCoefficientsFeatureOBP,
+        sbf.multicast.SeaBreezeMulticastFeatureOBP,
     )
 
 

--- a/src/seabreeze/pyseabreeze/features/multicast.py
+++ b/src/seabreeze/pyseabreeze/features/multicast.py
@@ -1,5 +1,6 @@
+import struct
 from seabreeze.pyseabreeze.features._base import SeaBreezeFeature
-
+from seabreeze.pyseabreeze.protocol import OBPProtocol
 
 # Definition
 # ==========
@@ -16,3 +17,41 @@ class SeaBreezeMulticastFeature(SeaBreezeFeature):
         self, interface_index: int, enable_state: bool
     ) -> None:
         raise NotImplementedError("implement in derived class")
+
+    def get_multicast_group_address(self, interface_index: int) -> tuple[int, int , int, int]:
+        raise NotImplementedError("implement in derived class")
+
+    def get_multicast_group_port(self, interface_index: int) -> int:
+        raise NotImplementedError("implement in derived class")
+
+    def get_multicast_ttl(self, interface_index: int) -> int:
+        raise NotImplementedError("implement in derived class")
+
+
+# OBP implementation
+# ==================
+#
+class SeaBreezeMulticastFeatureOBP(SeaBreezeMulticastFeature):
+    _required_protocol_cls = OBPProtocol
+
+    def get_multicast_enable_state(self, interface_index: int) -> bool:
+        ret = self.protocol.query(0x00000A80, int(interface_index))
+        return bool(struct.unpack("<B", ret))
+
+    def set_multicast_enable_state(
+        self, interface_index: int, enable_state: bool
+    ) -> None:
+        raise NotImplementedError("missing from HDX FW documentation")
+
+    def get_multicast_group_address(self, interface_index: int) -> tuple[int, int, int, int]:
+        ret = self.protocol.query(0x00000A81, int(interface_index))
+        ip = struct.unpack("<BBBB", ret)
+        return ip
+
+    def get_multicast_group_port(self, interface_index: int) -> int:
+        ret = self.protocol.query(0x00000A82, int(interface_index))
+        return struct.unpack("<H", ret)
+
+    def get_multicast_ttl(self, interface_index: int) -> int:
+        ret = self.protocol.query(0x00000A83, int(interface_index))
+        return struct.unpack("<B", ret)

--- a/src/seabreeze/pyseabreeze/features/multicast.py
+++ b/src/seabreeze/pyseabreeze/features/multicast.py
@@ -1,6 +1,9 @@
 import struct
+from typing import List
+
 from seabreeze.pyseabreeze.features._base import SeaBreezeFeature
 from seabreeze.pyseabreeze.protocol import OBPProtocol
+
 
 # Definition
 # ==========
@@ -18,7 +21,7 @@ class SeaBreezeMulticastFeature(SeaBreezeFeature):
     ) -> None:
         raise NotImplementedError("implement in derived class")
 
-    def get_multicast_group_address(self, interface_index: int) -> tuple[int, int , int, int]:
+    def get_multicast_group_address(self, interface_index: int) -> List[int]:
         raise NotImplementedError("implement in derived class")
 
     def get_multicast_group_port(self, interface_index: int) -> int:
@@ -43,15 +46,15 @@ class SeaBreezeMulticastFeatureOBP(SeaBreezeMulticastFeature):
     ) -> None:
         raise NotImplementedError("missing from HDX FW documentation")
 
-    def get_multicast_group_address(self, interface_index: int) -> tuple[int, int, int, int]:
+    def get_multicast_group_address(self, interface_index: int) -> List[int]:
         ret = self.protocol.query(0x00000A81, int(interface_index))
         ip = struct.unpack("<BBBB", ret)
-        return ip
+        return [int(ip[0]), int(ip[1]), int(ip[2]), int(ip[3])]
 
     def get_multicast_group_port(self, interface_index: int) -> int:
         ret = self.protocol.query(0x00000A82, int(interface_index))
-        return struct.unpack("<H", ret)
+        return int(struct.unpack("<H", ret)[0])
 
     def get_multicast_ttl(self, interface_index: int) -> int:
         ret = self.protocol.query(0x00000A83, int(interface_index))
-        return struct.unpack("<B", ret)
+        return int(struct.unpack("<B", ret)[0])

--- a/src/seabreeze/pyseabreeze/protocol.py
+++ b/src/seabreeze/pyseabreeze/protocol.py
@@ -233,6 +233,9 @@ class OBPProtocol(PySeaBreezeProtocol):
             0x00000A81: "<B",  # GET_MC_GROUP_ADDR
             0x00000A82: "<B",  # GET_MC_GROUP_PORT
             0x00000A83: "<B",  # GET_MC_TTL
+            0xE11: "",  # GET_DEV_STR
+            0xE00: "",  # GET_VID
+            0xE01: "",  # GET_PID
         }.items()
     }  # add more here if you implement new features
 

--- a/src/seabreeze/pyseabreeze/protocol.py
+++ b/src/seabreeze/pyseabreeze/protocol.py
@@ -229,6 +229,10 @@ class OBPProtocol(PySeaBreezeProtocol):
             0x00420004: "",  # GET_TE_TEMPERATURE
             0x00420010: "<B",  # SET_TE_ENABLE
             0x00420011: "<f",  # SET_TE_SETPOINT
+            0x00000A80: "<B", # GET_MC_ENABLED
+            0x00000A81: "<B", # GET_MC_GROUP_ADDR
+            0x00000A82: "<B", # GET_MC_GROUP_PORT
+            0x00000A83: "<B", # GET_MC_TTL
         }.items()
     }  # add more here if you implement new features
 

--- a/src/seabreeze/pyseabreeze/protocol.py
+++ b/src/seabreeze/pyseabreeze/protocol.py
@@ -229,10 +229,10 @@ class OBPProtocol(PySeaBreezeProtocol):
             0x00420004: "",  # GET_TE_TEMPERATURE
             0x00420010: "<B",  # SET_TE_ENABLE
             0x00420011: "<f",  # SET_TE_SETPOINT
-            0x00000A80: "<B", # GET_MC_ENABLED
-            0x00000A81: "<B", # GET_MC_GROUP_ADDR
-            0x00000A82: "<B", # GET_MC_GROUP_PORT
-            0x00000A83: "<B", # GET_MC_TTL
+            0x00000A80: "<B",  # GET_MC_ENABLED
+            0x00000A81: "<B",  # GET_MC_GROUP_ADDR
+            0x00000A82: "<B",  # GET_MC_GROUP_PORT
+            0x00000A83: "<B",  # GET_MC_TTL
         }.items()
     }  # add more here if you implement new features
 

--- a/src/seabreeze/pyseabreeze/transport.py
+++ b/src/seabreeze/pyseabreeze/transport.py
@@ -523,7 +523,7 @@ class IPv4Transport(PySeaBreezeTransport[IPv4TransportHandle]):
         sock.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
         # Set a timeout so the socket does not block
         # indefinitely when trying to receive data.
-        sock.settimeout(kwargs.get("multicast_timeout", 2))
+        sock.settimeout(kwargs.get("multicast_timeout", 1))
         sock.setsockopt(
             socket.IPPROTO_IP,
             socket.IP_MULTICAST_IF,

--- a/src/seabreeze/pyseabreeze/transport.py
+++ b/src/seabreeze/pyseabreeze/transport.py
@@ -506,8 +506,6 @@ class IPv4Transport(PySeaBreezeTransport[IPv4TransportHandle]):
         devices : IPv4TransportHandle
             unique socket devices for each available spectrometer
         """
-        dev_sockets = []
-
         # Use multicast to discover potential spectrometers. If no network
         # adapter was specified use INADDR_ANY: an appropriate interface is
         # chosen by the system (see ip(7)). This is usually the interface with
@@ -570,6 +568,7 @@ class IPv4Transport(PySeaBreezeTransport[IPv4TransportHandle]):
                 )
 
         # connect to discovered and registered devices
+        dev_sockets = []
         for address in cls.devices_ip_port:
             sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
             try:

--- a/src/seabreeze/pyseabreeze/transport.py
+++ b/src/seabreeze/pyseabreeze/transport.py
@@ -527,8 +527,7 @@ class IPv4Transport(PySeaBreezeTransport[IPv4TransportHandle]):
             # indefinitely when trying to receive data.
             sock.settimeout(kwargs.get("multicast_timeout", 2))
             sock.setsockopt(socket.IPPROTO_IP, socket.IP_MULTICAST_IF, socket.inet_aton(network_adapter))
-            handle = IPv4TransportHandle(sock)
-            transport = IPv4Transport(handle)
+            transport = IPv4Transport(OBPProtocol)
             protocol = OBPProtocol(transport)
             msg_type = 0x00000100  # GET_SERIAL
             data = protocol.msgs[msg_type](*())

--- a/src/seabreeze/pyseabreeze/transport.py
+++ b/src/seabreeze/pyseabreeze/transport.py
@@ -593,12 +593,9 @@ class IPv4Transport(PySeaBreezeTransport[IPv4TransportHandle]):
         ----------
         device : IPv4TransportHandle
         """
-        # TODO implement this method
         if not isinstance(device, IPv4TransportHandle):
             return None
-        # noinspection PyUnresolvedReferences
-        # FIXME return something other then a hard-coded string
-        return "HDX"
+        return cls.devices_ip_port[device.identity]
 
     @classmethod
     def specialize(cls, model_name: str, **kwargs: Any) -> type[IPv4Transport]:
@@ -615,7 +612,7 @@ class IPv4Transport(PySeaBreezeTransport[IPv4TransportHandle]):
 
     @classmethod
     def initialize(cls, **_kwargs: Any) -> None:
-        # TODO implement socket resent (close/open?)
+        # TODO implement socket reset? (close/open?)
         pass
 
     @classmethod

--- a/src/seabreeze/pyseabreeze/transport.py
+++ b/src/seabreeze/pyseabreeze/transport.py
@@ -393,7 +393,12 @@ class IPv4TransportHandle:
             address, port = sock.getpeername()
         except OSError:
             address, port = None, None
-        self.identity: tuple[str, int] = (address, port)
+        self.identity: DeviceIdentity = (
+            int(ipaddress.IPv4Address(address)),
+            port,
+            0,
+            0,
+        )
         # register callback to close socket on garbage collection
         self._finalizer = weakref.finalize(self, self.socket.close)
 
@@ -608,7 +613,12 @@ class IPv4Transport(PySeaBreezeTransport[IPv4TransportHandle]):
         """
         if not isinstance(device, IPv4TransportHandle):
             return None
-        return cls.devices_ip_port[device.identity]
+        return cls.devices_ip_port[
+            # IP address
+            (str(ipaddress.IPv4Address(device.identity[0]))),
+            # port
+            device.identity[1],
+        ]
 
     @classmethod
     def specialize(cls, model_name: str, **kwargs: Any) -> type[IPv4Transport]:

--- a/src/seabreeze/pyseabreeze/transport.py
+++ b/src/seabreeze/pyseabreeze/transport.py
@@ -548,7 +548,6 @@ class IPv4Transport(PySeaBreezeTransport[IPv4TransportHandle]):
             request_ack=True,
         )
         sock.sendto(message, (multicast_group, multicast_port))
-        print("Waiting to receive multicast response(s)")
         while True:
             try:
                 data = bytearray(90)

--- a/src/seabreeze/pyseabreeze/transport.py
+++ b/src/seabreeze/pyseabreeze/transport.py
@@ -504,11 +504,17 @@ class IPv4Transport(PySeaBreezeTransport[IPv4TransportHandle]):
             unique socket devices for each available spectrometer
         """
         # TODO use multicast to discover potential spectrometers
-        sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
-        # FIXME this uses the default address only
-        sock.connect(('192.168.254.254', 57357))
-        for dev in range(1):
-            yield IPv4TransportHandle(sock)
+        dev_sockets = []
+        for address, model in cls.devices_ip_port.items():
+            sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+            try:
+                sock.connect(address)
+            except OSError as e:
+                raise RuntimeError(f"Could not connect to {address}: {e}")
+            else:
+                dev_sockets.append(sock)
+        for dev in dev_sockets:
+            yield IPv4TransportHandle(dev)
 
     @classmethod
     def register_model(cls, model_name: str, **kwargs: Any) -> None:

--- a/src/seabreeze/pyseabreeze/transport.py
+++ b/src/seabreeze/pyseabreeze/transport.py
@@ -541,7 +541,7 @@ class IPv4Transport(PySeaBreezeTransport[IPv4TransportHandle]):
         transport = IPv4Transport(OBPProtocol)
         protocol = OBPProtocol(transport)
         msg_type = 0xE01  # Product ID
-        data = protocol.msgs[msg_type](*())
+        data = protocol.msgs[msg_type]()
         message = protocol._construct_outgoing_message(
             msg_type,
             data,

--- a/src/seabreeze/pyseabreeze/transport.py
+++ b/src/seabreeze/pyseabreeze/transport.py
@@ -380,7 +380,7 @@ def get_name_from_pyusb_backend(backend: usb.backend.IBackend) -> str | None:
 # this can and should be opaque to pyseabreeze
 class IPv4TransportHandle:
     def __init__(
-        self, socket: socket.socket, address: str = None, port: int = None
+        self, sock: socket.socket
     ) -> None:
         """encapsulation for IPv4 socket classes
 
@@ -388,8 +388,12 @@ class IPv4TransportHandle:
         ----------
 
         """
-        self.socket: socket.socket = socket
+        self.socket: socket.socket = sock
         # TODO check if socket is connected and get address via socket (socket.getpeername())
+        try:
+            address, port = sock.getpeername()
+        except OSError:
+            address, port = None, None
         self.identity: tuple[str, int] = (address, port)
 
     def close(self) -> None:

--- a/src/seabreeze/pyseabreeze/transport.py
+++ b/src/seabreeze/pyseabreeze/transport.py
@@ -622,10 +622,8 @@ class IPv4Transport(PySeaBreezeTransport[IPv4TransportHandle]):
 
     @classmethod
     def initialize(cls, **_kwargs: Any) -> None:
-        # TODO implement socket reset? (close/open?)
         pass
 
     @classmethod
     def shutdown(cls, **_kwargs: Any) -> None:
-        # TODO implement
         pass

--- a/src/seabreeze/pyseabreeze/transport.py
+++ b/src/seabreeze/pyseabreeze/transport.py
@@ -568,11 +568,15 @@ class IPv4Transport(PySeaBreezeTransport[IPv4TransportHandle]):
                 # use known product ids of the USB transport to look up the model name
                 vid = 0x2457  # Ocean vendor ID
                 model = USBTransport.vendor_product_ids[(vid, pid)]
-                cls.register_model(
-                    model_name=model,
-                    ipv4_address=server[0],
-                    ipv4_port=server[1],
-                )
+                try:
+                    cls.register_model(
+                        model_name=model,
+                        ipv4_address=server[0],
+                        ipv4_port=server[1],
+                    )
+                except ValueError:
+                    # device already known
+                    pass
 
         # connect to discovered and registered devices
         dev_sockets = []


### PR DESCRIPTION
This PR adds basic support for a network transport by adding the necessary classes `IPv4Transport` and `IPv4TransportHandle` that communicate over `socket` to the `pyseabreeze` backend.

It supports multicast to discover devices on the local network. Tests were done using an HDX spectrometer connected via ethernet (direct link).

Please note that this is a best-effort proof-of-concept at this point:
- ~~no~~ few exceptions from the `socket` library are handled yet
- ~~there is no discovery of devices, only registration of known devices via `api.add_ipv4_device_location`; this could be replaced by multicast discovery~~
- ~~the `HDX` device is hard-coded to `IPv4Transport`; having both transports there caused issues~~
- ~~some methods are basically placeholders and still require implementation~~
- no extensive tests beyond reading intensities has been done yet nor have any unit tests been implemented

Feedback on proper integration into the framework and best-practices welcome!

Sample run:
```
In [1]: import seabreeze.pyseabreeze as psb
   ...: # specifying a network adapter will enable multicast:
   ...: api = psb.SeaBreezeAPI(network_adapter="192.168.254.200")
   ...: # alternatively: add device and address manually: 
   ...: # api.add_ipv4_device_location("HDX", "192.168.254.254", 57357)
   ...: devices = api.list_devices()
Waiting to receive multicast response(s)

In [2]: devices
Out[2]: [<SeaBreezeDevice QE65000:QEPB01234>, <SeaBreezeDevice HDX:HDX01234>]

In [3]: import seabreeze
   ...: seabreeze.use('pyseabreeze')
   ...: from seabreeze.spectrometers import Spectrometer

In [4]: spec = Spectrometer(device=devices[1])

In [5]: spec.intensities(0,1)
Out[5]: 
array([1978.05266071, 1332.67455752, 1433.36236484, ..., 1415.41637616,
       1417.41034014, 1416.41335706])

In [6]: spec.model
Out[6]: 'HDX'

```
(note that I replaced the serial in the output above)

Left to be done:
- [x] fix remaining typing errors
- [x] test that both USB and ethernet work with the HDX
- [x] consider to refactorize the packet generation for the multicast request and the model name matching
- [x] implement `shutdown` and `initialize`  of `IPv4Transport` (or remove `TODO` comment)
- [ ] multicast feature: investigate why requests for multicast group and port do not work (or remove implementation)

Addresses #240.