### PR TITLE
Support for HR4

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,6 +41,16 @@ conda install -c conda-forge seabreeze
 seabreeze_os_setup
 ```
 
+### Using the backend pyseabreeze in Windows
+The backend pyseabreeze requires the libraries pyusb and libusb
+```bash
+# via pypi
+pip install pyusb
+pip install libusb
+```
+Additionally, you might need to manually add a libusb-1.0.dll library to the system. Go here https://libusb.info/, Downloads -> Latest Windows Binaries. In the zip file, enter either the folder MinGW64/dll or MinGW32/dll (depending on your OS). Copy the file  libusb-1.0.dll into C:\Windows\System32.
+
+
 ## Usage
 
 The following example shows how simple it is to acquire a spectrum with

--- a/README.md
+++ b/README.md
@@ -42,13 +42,13 @@ seabreeze_os_setup
 ```
 
 ### Using the backend pyseabreeze in Windows
+
 The backend pyseabreeze requires the libraries pyusb and libusb
 ```bash
 # via pypi
-pip install pyusb
-pip install libusb
+pip install seabreeze[pyseabreeze]  # this ensures installation of pyusb
 ```
-Additionally, you might need to manually add a libusb-1.0.dll library to the system. Go here https://libusb.info/, Downloads -> Latest Windows Binaries. In the zip file, enter either the folder MinGW64/dll or MinGW32/dll (depending on your OS). Copy the file  libusb-1.0.dll into C:\Windows\System32.
+Additionally, you might need to manually install libusb1. Go here https://libusb.info/, Downloads -> Latest Windows Binaries. In the zip file, enter either the folder MinGW64/dll or MinGW32/dll (depending on your OS). Copy the file `libusb-1.0.dll` into `C:\Windows\System32`.
 
 
 ## Usage

--- a/os_support/10-oceanoptics.rules
+++ b/os_support/10-oceanoptics.rules
@@ -1,8 +1,8 @@
 # udev rules file for Ocean Optics, Inc. spectrometers
 # ====================================================
 #
-# version: 2.7
-# updated: 2024-05-29
+# version: 2.8
+# updated: 2024-06-01
 # maintainer: Andreas Poehlmann <andreas@poehlmann.io>
 #
 # [info] Previous versions are missing this header.
@@ -14,6 +14,7 @@
 #   $ seabreeze_os_setup
 #
 # Changes:
+# - [2.8] added support for HR4 spectrometer
 # - [2.7] added support for HR2 spectrometer
 # - [2.6] added support for SR6 spectrometer
 # - [2.5] added support for SR2 spectrometer
@@ -90,7 +91,7 @@ ATTR{idVendor}=="04b4", ATTR{idProduct}=="8613", SYMLINK+="ezUSB-FX2-%n", MODE:=
 ATTR{idVendor}=="2457", ATTR{idProduct}=="2003", SYMLINK+="oceanhdx-%n", MODE:="0666"
 # Ocean Insight Inc. ST spectrometer
 ATTR{idVendor}=="0999", ATTR{idProduct}=="1000", SYMLINK+="st-%n", MODE:="0666"
-# Ocean Insight Inc. SR4 spectrometer
+# Ocean Insight Inc. SR2 spectrometer
 ATTR{idVendor}=="0999", ATTR{idProduct}=="1001", SYMLINK+="sr2-%n", MODE:="0666"
 # Ocean Insight Inc. SR4 spectrometer
 ATTR{idVendor}=="0999", ATTR{idProduct}=="1002", SYMLINK+="sr4-%n", MODE:="0666"

--- a/os_support/10-oceanoptics.rules
+++ b/os_support/10-oceanoptics.rules
@@ -98,5 +98,7 @@ ATTR{idVendor}=="0999", ATTR{idProduct}=="1002", SYMLINK+="sr4-%n", MODE:="0666"
 ATTR{idVendor}=="0999", ATTR{idProduct}=="1005", SYMLINK+="sr6-%n", MODE:="0666"
 # Ocean Insight Inc. HR2 Spectrometer
 ATTR{idVendor}=="0999", ATTR{idProduct}=="1003", SYMLINK+="hr2-%n", MODE:="0666"
+# Ocean Insight Inc. HR4 Spectrometer
+ATTR{idVendor}=="0999", ATTR{idProduct}=="1004", SYMLINK+="hr4-%n", MODE:="0666"
 
 LABEL="oceanoptics_rules_end"

--- a/src/seabreeze/pyseabreeze/devices.py
+++ b/src/seabreeze/pyseabreeze/devices.py
@@ -1299,6 +1299,7 @@ class HR2(SeaBreezeDevice):
     # features
     feature_classes = (sbf.spectrometer.SeaBreezeSpectrometerFeatureHR2,)
 
+
 class HR4(SeaBreezeDevice):
     model_name = "HR4"
 

--- a/src/seabreeze/pyseabreeze/devices.py
+++ b/src/seabreeze/pyseabreeze/devices.py
@@ -1299,6 +1299,29 @@ class HR2(SeaBreezeDevice):
     # features
     feature_classes = (sbf.spectrometer.SeaBreezeSpectrometerFeatureHR2,)
 
+class HR4(SeaBreezeDevice):
+    model_name = "HR4"
+
+    # communication config
+    transport = (USBTransport,)
+    usb_vendor_id = 0x0999
+    usb_product_id = 0x1004
+    usb_endpoint_map = EndPointMap(ep_out=0x01, highspeed_in=0x81)
+    usb_protocol = OBP2Protocol
+
+    # spectrometer config
+    dark_pixel_indices = DarkPixelIndices.from_ranges()
+    integration_time_min = 3800  # 3.8ms
+    integration_time_max = 10000000  # 10s
+    integration_time_base = 1
+    spectrum_num_pixel = 3648
+    spectrum_raw_length = (3648 * 2) + 32  # XXX: Metadata
+    spectrum_max_value = 65535
+    trigger_modes = TriggerMode.supported("OBP_NORMAL")
+
+    # features
+    feature_classes = (sbf.spectrometer.SeaBreezeSpectrometerFeatureHR4,)
+
 
 class ST(SeaBreezeDevice):
     model_name = "ST"

--- a/src/seabreeze/pyseabreeze/features/spectrometer.py
+++ b/src/seabreeze/pyseabreeze/features/spectrometer.py
@@ -738,3 +738,6 @@ class SeaBreezeSpectrometerFeatureHR2(SeaBreezeSpectrometerFeatureOBP):
         # and generate the wavelength array
         indices = numpy.arange(self._spectrum_length, dtype=numpy.float64)
         return sum(wl * (indices**i) for i, wl in enumerate(coeffs))  # type: ignore
+
+class SeaBreezeSpectrometerFeatureHR4(SeaBreezeSpectrometerFeatureOBP2):
+    pass

--- a/src/seabreeze/pyseabreeze/features/spectrometer.py
+++ b/src/seabreeze/pyseabreeze/features/spectrometer.py
@@ -739,5 +739,6 @@ class SeaBreezeSpectrometerFeatureHR2(SeaBreezeSpectrometerFeatureOBP):
         indices = numpy.arange(self._spectrum_length, dtype=numpy.float64)
         return sum(wl * (indices**i) for i, wl in enumerate(coeffs))  # type: ignore
 
+
 class SeaBreezeSpectrometerFeatureHR4(SeaBreezeSpectrometerFeatureOBP2):
     pass


### PR DESCRIPTION
Adding basic support for HR4. Some of the settings (integration time, number of pixels, etc.) were taken from the manual, others were copied from the settings of the SR4, which seems to be the "closest" model. I tried it with my own HR4 spectrometer on Windows 10 and it seems to work well.

Since this device (and other recent ones) only work with the pyseabreeze backend, it might be worth it to add a few instructions to the README regarding how to properly install pyusb in Windows; in my case, I had to manually add a .dll file. I added some new instructions in the README file in this commit, feel free to ignore it or change it.

Test:
```
================================================= test session starts =================================================
platform win32 -- Python 3.12.0, pytest-8.2.1, pluggy-1.5.0 -- C:\Users\CotrufoResearchLab\Desktop\test_oceanoptics3\Scripts\python.exe
cachedir: .pytest_cache
rootdir: C:\Users\CotrufoResearchLab\Desktop\python-seabreeze
configfile: pytest.ini
collected 28 items

tests/test_backends.py::test_seabreeze_installed PASSED                                                          [  3%]
tests/test_backends.py::test_seabreeze_wrong_backend_requested PASSED                                            [  7%]
tests/test_backends.py::test_seabreeze_any_backend_available[cseabreeze] PASSED                                  [ 10%]
tests/test_backends.py::test_seabreeze_any_backend_available[pyseabreeze] PASSED                                 [ 14%]
tests/test_backends.py::test_seabreeze_cseabreeze_backend_available PASSED                                       [ 17%]
tests/test_backends.py::test_seabreeze_pyseabreeze_backend_available PASSED                                      [ 21%]
tests/test_backends.py::test_seabreeze_cseabreeze_api_init PASSED                                                [ 25%]
tests/test_backends.py::test_seabreeze_pyseabreeze_api_init[any] PASSED                                          [ 28%]
tests/test_backends.py::test_seabreeze_pyseabreeze_api_init[openusb] PASSED                                      [ 32%]
tests/test_backends.py::test_seabreeze_pyseabreeze_api_init[libusb0] PASSED                                      [ 35%]
tests/test_backends.py::test_seabreeze_pyseabreeze_api_init[libusb1] PASSED                                      [ 39%]
tests/test_backends.py::test_seabreeze_compare_backend_feature_interfaces PASSED                                 [ 42%]
tests/test_protocol.py::test_pyseabreeze_protocol_messages PASSED                                                [ 46%]
tests/test_spectrometers.py::TestHardware::test_cant_find_serial[backend(any)] PASSED                            [ 50%]
tests/test_spectrometers.py::TestHardware::test_device_cleanup_on_exit[backend(any)] PASSED                      [ 53%]
tests/test_spectrometers.py::TestHardware::test_read_model[HR4:HR400412-backend(any)] PASSED                     [ 57%]
tests/test_spectrometers.py::TestHardware::test_read_serial_number[HR4:HR400412-backend(any)] PASSED             [ 60%]
tests/test_spectrometers.py::TestHardware::test_crash_may_not_influence_following_tests[HR4:HR400412-backend(any)] SKIPPED [ 64%]
tests/test_spectrometers.py::TestHardware::test_read_intensities[HR4:HR400412-backend(any)] PASSED               [ 67%]
tests/test_spectrometers.py::TestHardware::test_correct_dark_pixels[HR4:HR400412-backend(any)] SKIPPED (does...) [ 71%]
tests/test_spectrometers.py::TestHardware::test_read_wavelengths[HR4:HR400412-backend(any)] PASSED               [ 75%]
tests/test_spectrometers.py::TestHardware::test_read_spectrum[HR4:HR400412-backend(any)] PASSED                  [ 78%]
tests/test_spectrometers.py::TestHardware::test_max_intensity[HR4:HR400412-backend(any)] PASSED                  [ 82%]
tests/test_spectrometers.py::TestHardware::test_integration_time_limits[HR4:HR400412-backend(any)] PASSED        [ 85%]
tests/test_spectrometers.py::TestHardware::test_integration_time[HR4:HR400412-backend(any)] PASSED               [ 89%]
tests/test_spectrometers.py::TestHardware::test_trigger_mode[HR4:HR400412-backend(any)] PASSED                   [ 92%]
tests/test_spectrometers.py::TestHardware::test_trigger_mode_wrong[HR4:HR400412-backend(any)] PASSED             [ 96%]
tests/test_spectrometers.py::TestHardware::test_list_devices_dont_close_opened_devices[backend(any)] PASSED      [100%]

=============================================== short test summary info ===============================================
SKIPPED [1] tests\test_spectrometers.py:237: FIXME: TEST BREAKS OTHER TESTS ON WINDOWS
SKIPPED [1] tests\test_spectrometers.py:265: does not support dark counts
============================================ 26 passed, 2 skipped in 4.36s ============================================
```