### PR TITLE
Improve error message when a wrong type is passed to `Spectrometer`

### DIFF
--- a/src/seabreeze/spectrometers.py
+++ b/src/seabreeze/spectrometers.py
@@ -112,7 +112,9 @@ class Spectrometer:
             a SeaBreezeDevice as returned from `list_devices`
         """
         if not isinstance(device, self._backend.SeaBreezeDevice):
-            raise TypeError("`device` has to be a `SeaBreezeDevice` instance")
+            raise TypeError(
+                f"`device` has to be a `SeaBreezeDevice` instance, got {device!r}"
+            )
         self._dev = device
         self.open()  # always open the device here to allow caching values
 


### PR DESCRIPTION
Previously the error message was
```
TypeError: device has to be a `SeaBreezeDevice`
```
which could be misinterpreted:
it is the variable that has an incorrect type, not the physical spectrometer.

Also display the representation of `device`, following this example:
https://docs.python.org/3/howto/descriptor.html
